### PR TITLE
use panel API for config fetching

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ Flask subscription aggregator for Marzneshin
 - Returns only configs (ss://, vless://, vmess://, trojan://), one per line (text/plain)
 - Enforces local quota. If user quota exceeded -> empty body + DISABLE remote (once).
 - NEW: Enforces AGENT-level quota/expiry too: if agent exhausted/expired -> empty body + DISABLE ALL agent users (once).
-- Panel-level subscription URL + per-panel disabled config-name filters (anything after '#' is the name).
+- Supports per-panel disabled config-name filters (anything after '#' is the name).
 """
 
 import os
@@ -77,20 +77,36 @@ def get_local_user(owner_id, local_username):
         return cur.fetchone()
 
 def list_mapped_links(owner_id, local_username):
+    """Return panel link mappings for a local user.
+
+    Only the data required for API-based subscription fetching is selected; any
+    panel-level subscription URL configured for name filtering is ignored here.
+    """
     with CurCtx() as cur:
-        cur.execute("""
+        cur.execute(
+            """
             SELECT lup.panel_id, lup.remote_username,
-                   p.panel_url, p.access_token, p.sub_url
+                   p.panel_url, p.access_token
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
-        """, (owner_id, local_username))
+            """,
+            (owner_id, local_username),
+        )
         return cur.fetchall()
 
 def list_all_panels(owner_id):
-    # owner_id اینجا همان ادمین پنل‌ها نیست؛ برای fallback عمومی همین را می‌خوانیم
+    """List all panels for an owner for fallback resolution.
+
+    Subscription URLs stored for config-name filtering are intentionally not
+    returned as the unified subscription now fetches configs directly via the
+    panel API.
+    """
     with CurCtx() as cur:
-        cur.execute("SELECT id, panel_url, access_token, sub_url FROM panels WHERE telegram_user_id=%s", (owner_id,))
+        cur.execute(
+            "SELECT id, panel_url, access_token FROM panels WHERE telegram_user_id=%s",
+            (owner_id,),
+        )
         return cur.fetchall()
 
 def mark_user_disabled(owner_id, local_username):
@@ -103,7 +119,9 @@ def mark_user_disabled(owner_id, local_username):
 
 def disable_remote(panel_url, token, remote_username):
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"/api/users/{remote_username}/disable")
+        # panel_url may already include a path component; urljoin with a leading
+        # slash would discard it. Join paths relative to preserve subpaths.
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
         r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
         return r.status_code, r.text[:200]
     except Exception as e:
@@ -111,7 +129,7 @@ def disable_remote(panel_url, token, remote_username):
 
 def fetch_user(panel_url: str, token: str, remote_username: str):
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"/api/users/{remote_username}")
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
         r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
         if r.status_code != 200:
             return None
@@ -121,24 +139,8 @@ def fetch_user(panel_url: str, token: str, remote_username: str):
 
 def fetch_links_from_panel(panel_url: str, remote_username: str, key: str):
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"/sub/{remote_username}/{key}/links")
+        url = urljoin(panel_url.rstrip("/") + "/", f"sub/{remote_username}/{key}/links")
         r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
-        try:
-            if r.headers.get("content-type","").startswith("application/json"):
-                data = r.json()
-                if isinstance(data, list):
-                    return [str(x) for x in data]
-                if isinstance(data, dict) and "links" in data:
-                    return [str(x) for x in data["links"]]
-        except:
-            pass
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
-    except:
-        return []
-
-def fetch_links_by_url(sub_url: str):
-    try:
-        r = requests.get(sub_url, headers={"accept": "application/json,text/plain"}, timeout=20)
         try:
             if r.headers.get("content-type","").startswith("application/json"):
                 data = r.json()
@@ -271,19 +273,18 @@ def unified_links(local_username, app_key):
         resp.headers["X-Disabled-Pushed"] = "1"
         return resp
 
-    # ---- Aggregate & filter links (panel-level sub_url + per-panel name filters) ----
+    # ---- Aggregate & filter links (per-panel config-name filters) ----
     mapped = list_mapped_links(owner_id, local_username)
     all_links = []
     if mapped:
         for l in mapped:
             disabled = get_panel_disabled_names(l["panel_id"])
             links = []
-            if l.get("sub_url"):
-                links = fetch_links_by_url(l["sub_url"])
-            else:
-                u = fetch_user(l["panel_url"], l["access_token"], l["remote_username"])
-                if u and u.get("key"):
-                    links = fetch_links_from_panel(l["panel_url"], l["remote_username"], u["key"])
+            u = fetch_user(l["panel_url"], l["access_token"], l["remote_username"])
+            if u and u.get("key"):
+                links = fetch_links_from_panel(
+                    l["panel_url"], l["remote_username"], u["key"]
+                )
             if disabled:
                 links = [x for x in links if (extract_name(x) or "") not in disabled]
             all_links.extend(links)
@@ -291,12 +292,11 @@ def unified_links(local_username, app_key):
         for p in list_all_panels(owner_id):
             disabled = get_panel_disabled_names(p["id"])
             links = []
-            if p.get("sub_url"):
-                links = fetch_links_by_url(p["sub_url"])
-            else:
-                u = fetch_user(p["panel_url"], p["access_token"], local_username)
-                if u and u.get("key"):
-                    links = fetch_links_from_panel(p["panel_url"], local_username, u["key"])
+            u = fetch_user(p["panel_url"], p["access_token"], local_username)
+            if u and u.get("key"):
+                links = fetch_links_from_panel(
+                    p["panel_url"], local_username, u["key"]
+                )
             if disabled:
                 links = [x for x in links if (extract_name(x) or "") not in disabled]
             all_links.extend(links)

--- a/usage_sync.py
+++ b/usage_sync.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import requests
 from dotenv import load_dotenv
 from mysql.connector import pooling
+import mysql.connector
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -50,26 +51,57 @@ class CurCtx:
 
 # ---------------- existing per-link / per-user logic ----------------
 
+def ensure_links_table():
+    """Create local_user_panel_links table if missing."""
+    with CurCtx(dict_=False) as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS local_user_panel_links(
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                owner_id BIGINT NOT NULL,
+                local_username VARCHAR(64) NOT NULL,
+                panel_id BIGINT NOT NULL,
+                remote_username VARCHAR(128) NOT NULL,
+                last_used_traffic BIGINT NOT NULL DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_link(owner_id, local_username, panel_id),
+                FOREIGN KEY (panel_id) REFERENCES panels(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+            """
+        )
+
+
 def fetch_all_links():
-    with CurCtx() as cur:
-        cur.execute("""
-            SELECT lup.id AS link_id,
-                   lup.owner_id,
-                   lup.local_username,
-                   lup.panel_id,
-                   lup.remote_username,
-                   lup.last_used_traffic,
-                   p.panel_url,
-                   p.access_token
-            FROM local_user_panel_links lup
-            JOIN panels p ON p.id = lup.panel_id
-            ORDER BY lup.id ASC
-        """)
-        return cur.fetchall()
+    try:
+        with CurCtx() as cur:
+            cur.execute(
+                """
+                SELECT lup.id AS link_id,
+                       lup.owner_id,
+                       lup.local_username,
+                       lup.panel_id,
+                       lup.remote_username,
+                       lup.last_used_traffic,
+                       p.panel_url,
+                       p.access_token
+                FROM local_user_panel_links lup
+                JOIN panels p ON p.id = lup.panel_id
+                ORDER BY lup.id ASC
+                """
+            )
+            return cur.fetchall()
+    except mysql.connector.errors.ProgrammingError as e:
+        if getattr(e, "errno", None) == 1146:  # table doesn't exist
+            log.warning("local_user_panel_links table missing; creating")
+            ensure_links_table()
+            return []
+        raise
 
 def fetch_used_traffic(panel_url, bearer, remote_username):
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"/api/users/{remote_username}")
+        # Preserve any subpath in panel_url when joining API routes
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
         r = requests.get(url, headers={"Authorization": f"Bearer {bearer}"}, timeout=20)
         if r.status_code != 200:
             return None, f"{panel_url}: {r.status_code} {r.text[:120]}"
@@ -125,7 +157,7 @@ def mark_user_disabled(owner_id, local_username):
 
 def disable_remote(panel_url, token, remote_username):
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"/api/users/{remote_username}/disable")
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
         r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
         return r.status_code, r.text[:200]
     except Exception as e:


### PR DESCRIPTION
## Summary
- ignore panel subscription URLs and always fetch user configs via panel API
- clarify helper queries and docstring to reflect API-based fetching
- preserve panel URL subpaths when calling API endpoints
- auto-create `local_user_panel_links` table during usage sync to handle fresh databases

## Testing
- `python -m py_compile app.py usage_sync.py`
- `timeout 5 python usage_sync.py` *(fails: Can't connect to MySQL server on '127.0.0.1:3306')*


------
https://chatgpt.com/codex/tasks/task_b_68b4de8227ec83288bcfdad08bca99fd