### PR TITLE
Normalize disabled config names before filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,8 +177,16 @@ def extract_name(link: str) -> str:
 
 def get_panel_disabled_names(panel_id: int):
     with CurCtx() as cur:
-        cur.execute("SELECT config_name FROM panel_disabled_configs WHERE panel_id=%s", (int(panel_id),))
-        return {r["config_name"] for r in cur.fetchall()}
+        cur.execute(
+            "SELECT config_name FROM panel_disabled_configs WHERE panel_id=%s",
+            (int(panel_id),),
+        )
+        # Normalize names to match extract_name() output (strip & percent-decode)
+        return {
+            unquote(r["config_name"]).strip()
+            for r in cur.fetchall()
+            if (r["config_name"] or "").strip()
+        }
 
 # ---- agent-level ----
 def get_agent(owner_id: int):

--- a/bot.py
+++ b/bot.py
@@ -475,11 +475,26 @@ def get_panel(owner_id: int, panel_id: int):
 
 def get_panel_disabled_names(panel_id: int):
     with with_mysql_cursor() as cur:
-        cur.execute("SELECT config_name FROM panel_disabled_configs WHERE panel_id=%s", (int(panel_id),))
-        return [r["config_name"] for r in cur.fetchall()]
+        cur.execute(
+            "SELECT config_name FROM panel_disabled_configs WHERE panel_id=%s",
+            (int(panel_id),),
+        )
+        # Return normalized names so callers can match reliably
+        return [
+            unquote(r["config_name"]).strip()
+            for r in cur.fetchall()
+            if (r["config_name"] or "").strip()
+        ]
 
 def set_panel_disabled_names(owner_id: int, panel_id: int, names):
-    clean = list({ (n or "").strip()[:255] for n in names if n and n.strip() })
+    # Normalize and dedupe names (strip & percent-decode)
+    clean = list(
+        {
+            unquote((n or "").strip())[:255]
+            for n in names
+            if n and n.strip()
+        }
+    )
     with with_mysql_cursor() as cur:
         cur.execute("DELETE FROM panel_disabled_configs WHERE panel_id=%s", (int(panel_id),))
         if clean:


### PR DESCRIPTION
## Summary
- decode and strip stored disabled config names in both bot and web aggregator
- ensure sub filtering works with percent-encoded names

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py bot.py usage_sync.py`


------
https://chatgpt.com/codex/tasks/task_b_68b4e70f74b883289eb5edb78e23cf60