### PR TITLE
Re-enable users when quota restored

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,6 +50,8 @@ from telegram.ext import (
     MessageHandler, ContextTypes, filters
 )
 
+import usage_sync
+
 # ---------- logging ----------
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
@@ -379,15 +381,14 @@ def count_local_users(owner_id: int) -> int:
 def update_limit(owner_id: int, username: str, new_limit_bytes: int):
     with with_mysql_cursor() as cur:
         cur.execute(
-            "UPDATE local_users SET plan_limit_bytes=%s, disabled_pushed=IF(%s=0,0,disabled_pushed) "
-            "WHERE owner_id=%s AND username=%s",
-            (int(new_limit_bytes), int(new_limit_bytes), owner_id, username)
+            "UPDATE local_users SET plan_limit_bytes=%s WHERE owner_id=%s AND username=%s",
+            (int(new_limit_bytes), owner_id, username)
         )
 
 def reset_used(owner_id: int, username: str):
     with with_mysql_cursor() as cur:
         cur.execute(
-            "UPDATE local_users SET used_bytes=0, disabled_pushed=0 WHERE owner_id=%s AND username=%s",
+            "UPDATE local_users SET used_bytes=0 WHERE owner_id=%s AND username=%s",
             (owner_id, username)
         )
 
@@ -396,8 +397,7 @@ def renew_user(owner_id: int, username: str, add_days: int):
         cur.execute(
             """UPDATE local_users
                SET expire_at = IF(expire_at IS NULL, UTC_TIMESTAMP() + INTERVAL %s DAY,
-                                   expire_at + INTERVAL %s DAY),
-                   disabled_pushed = 0
+                                    expire_at + INTERVAL %s DAY)
                WHERE owner_id=%s AND username=%s""",
             (add_days, add_days, owner_id, username)
         )
@@ -526,8 +526,12 @@ def get_agent(tg_id: int):
 
 def set_agent_quota(tg_id: int, limit_bytes: int):
     with with_mysql_cursor() as cur:
-        cur.execute("UPDATE agents SET plan_limit_bytes=%s, disabled_pushed=0 WHERE telegram_user_id=%s",
+        cur.execute("UPDATE agents SET plan_limit_bytes=%s WHERE telegram_user_id=%s",
                     (int(limit_bytes), tg_id))
+    try:
+        usage_sync.sync_agent_now(tg_id)
+    except Exception as e:
+        log.warning("sync_agent_now failed for %s: %s", tg_id, e)
 
 def renew_agent_days(tg_id: int, add_days: int):
     # if no expire_at -> set now + days; else add days
@@ -535,10 +539,10 @@ def renew_agent_days(tg_id: int, add_days: int):
         cur.execute("SELECT expire_at FROM agents WHERE telegram_user_id=%s", (tg_id,))
         row = cur.fetchone()
         if row and row.get("expire_at"):
-            cur.execute("UPDATE agents SET expire_at = expire_at + INTERVAL %s DAY, disabled_pushed=0 WHERE telegram_user_id=%s",
+            cur.execute("UPDATE agents SET expire_at = expire_at + INTERVAL %s DAY WHERE telegram_user_id=%s",
                         (add_days, tg_id))
         else:
-            cur.execute("UPDATE agents SET expire_at = UTC_TIMESTAMP() + INTERVAL %s DAY, disabled_pushed=0 WHERE telegram_user_id=%s",
+            cur.execute("UPDATE agents SET expire_at = UTC_TIMESTAMP() + INTERVAL %s DAY WHERE telegram_user_id=%s",
                         (add_days, tg_id))
 
 def list_agents():

--- a/usage_sync.py
+++ b/usage_sync.py
@@ -34,6 +34,14 @@ def init_db():
         use_pure=True,
     )
 
+
+def init_if_needed():
+    """Initialize DB pool if not already initialized."""
+    global POOL
+    if POOL is None:
+        load_dotenv()
+        init_db()
+
 class CurCtx:
     def __init__(self, dict_=True):
         self.dict_ = dict_
@@ -163,6 +171,22 @@ def disable_remote(panel_url, token, remote_username):
     except Exception as e:
         return None, str(e)
 
+def enable_remote(panel_url, token, remote_username):
+    try:
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/enable")
+        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
+        return r.status_code, r.text[:200]
+    except Exception as e:
+        return None, str(e)
+
+def mark_user_enabled(owner_id, local_username):
+    with CurCtx() as cur:
+        cur.execute("""
+            UPDATE local_users
+            SET disabled_pushed=0, disabled_pushed_at=NULL
+            WHERE owner_id=%s AND username=%s
+        """, (owner_id, local_username))
+
 def try_disable_if_user_exceeded(owner_id, local_username):
     lu = get_local_user(owner_id, local_username)
     if not lu:
@@ -180,6 +204,24 @@ def try_disable_if_user_exceeded(owner_id, local_username):
             else:
                 log.info("disabled %s on %s", l["remote_username"], l["panel_url"])
         mark_user_disabled(owner_id, local_username)
+
+def try_enable_if_user_ok(owner_id, local_username):
+    lu = get_local_user(owner_id, local_username)
+    if not lu:
+        return
+    limit = int(lu["plan_limit_bytes"])
+    used = int(lu["used_bytes"])
+    pushed = int(lu.get("disabled_pushed", 0) or 0)
+
+    if pushed and (limit == 0 or used < limit):
+        links = list_links_of_local_user(owner_id, local_username)
+        for l in links:
+            code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+            if code and code != 200:
+                log.warning("enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
+            else:
+                log.info("enabled %s on %s", l["remote_username"], l["panel_url"])
+        mark_user_enabled(owner_id, local_username)
 
 # ---------------- NEW: Agent quota/expiry logic ----------------
 
@@ -246,6 +288,32 @@ def disable_user_on_assigned_panels(owner_id: int, username: str):
         else:
             log.info("(assigned) disabled %s on %s", username, p["panel_url"])
 
+def enable_user_on_assigned_panels(owner_id: int, username: str):
+    """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username فعال کن."""
+    panels = list_agent_assigned_panels(owner_id)
+    for p in panels:
+        code, msg = enable_remote(p["panel_url"], p["access_token"], username)
+        if code and code != 200:
+            log.warning("enable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
+        else:
+            log.info("(assigned) enabled %s on %s", username, p["panel_url"])
+
+def mark_agent_enabled(owner_id: int):
+    with CurCtx() as cur:
+        cur.execute("""
+            UPDATE agents
+            SET disabled_pushed=0, disabled_pushed_at=NULL
+            WHERE telegram_user_id=%s
+        """, (owner_id,))
+
+def mark_all_users_enabled(owner_id: int):
+    with CurCtx() as cur:
+        cur.execute("""
+            UPDATE local_users
+            SET disabled_pushed=0, disabled_pushed_at=NULL
+            WHERE owner_id=%s
+        """, (owner_id,))
+
 def try_disable_agent_if_exceeded(owner_id: int):
     """
     اگر نماینده limit داشته و از سقف گذشته یا expire_at گذشته و هنوز push نشده:
@@ -297,6 +365,56 @@ def try_disable_agent_if_exceeded(owner_id: int):
         mark_agent_disabled(owner_id)
         log.info("[AGENT] owner_id=%s disabled_pushed set for agent and all local users.", owner_id)
 
+def try_enable_agent_if_ok(owner_id: int):
+    ag = get_agent(owner_id)
+    if not ag:
+        return
+    if int(ag.get("active", 1)) == 0:
+        return
+    pushed = int(ag.get("disabled_pushed", 0) or 0)
+    if not pushed:
+        return
+
+    limit_b = int(ag.get("plan_limit_bytes") or 0)
+    expire_at = ag.get("expire_at")
+    now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+    expired = False
+    if expire_at:
+        try:
+            expired = (expire_at <= now_utc)
+        except Exception:
+            expired = False
+
+    over_limit = False
+    if limit_b > 0:
+        tot = total_used_by_owner(owner_id)
+        over_limit = (tot >= limit_b)
+
+    if not expired and not over_limit:
+        usernames = list_all_local_usernames(owner_id)
+        for uname in usernames:
+            links = list_links_of_local_user(owner_id, uname)
+            for l in links:
+                code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                if code and code != 200:
+                    log.warning("[AGENT] enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
+                else:
+                    log.info("[AGENT] enabled %s on %s", l["remote_username"], l["panel_url"])
+            enable_user_on_assigned_panels(owner_id, uname)
+        mark_all_users_enabled(owner_id)
+        mark_agent_enabled(owner_id)
+        log.info("[AGENT] owner_id=%s disabled_pushed cleared for agent and all local users.", owner_id)
+
+
+def sync_agent_now(owner_id: int):
+    """Public helper for bot to immediately re-check agent status."""
+    init_if_needed()
+    try:
+        try_disable_agent_if_exceeded(owner_id)
+        try_enable_agent_if_ok(owner_id)
+    except Exception as e:
+        log.warning("sync_agent_now failed for %s: %s", owner_id, e)
+
 # ---------------- main loop ----------------
 
 def loop():
@@ -327,15 +445,17 @@ def loop():
                     log.info("owner=%s local=%s +%s bytes (panel_id=%s)",
                              row["owner_id"], row["local_username"], delta, row["panel_id"])
 
-                # بعد از هر آپدیت، بررسی کن که آیا باید کاربر را disable کنیم
+                # بعد از هر آپدیت، وضعیت کاربر را بررسی کن (disable/enable)
                 try_disable_if_user_exceeded(row["owner_id"], row["local_username"])
+                try_enable_if_user_ok(row["owner_id"], row["local_username"])
 
                 # برای بهینگی، در پایان هر owner یک‌بار چک agent quota انجام می‌دهیم
                 seen_owners.add(int(row["owner_id"]))
 
-            # پس از پردازش همه لینک‌ها، کوتا/انقضای نماینده‌ها را چک کن
+            # پس از پردازش همه لینک‌ها، وضعیت نماینده‌ها را چک کن
             for owner_id in seen_owners:
                 try_disable_agent_if_exceeded(owner_id)
+                try_enable_agent_if_ok(owner_id)
 
         except Exception as e:
             log.exception("sync loop error: %s", e)


### PR DESCRIPTION
## Summary
- Re-enable disabled users once their quota or admin limits are lifted
- Automatically clear agent disable flags and re-enable their users when limits expire
- Trigger immediate agent usage sync after quota updates so re-enabling happens without waiting for the scheduled loop

## Testing
- `python -m py_compile bot.py usage_sync.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6e827e3c883289f785df55d46ab0c