### PR TITLE
Add Marzban panel support to usage sync

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1592,31 +1592,63 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
     for r in rows:
         api = get_api(r.get("panel_type"))
         if r.get("panel_type") == "marzneshin":
-            svc, e = api.fetch_user_services(r["panel_url"], r["access_token"], r.get("template_username"))
+            svc, e = api.fetch_user_services(
+                r["panel_url"], r["access_token"], r.get("template_username")
+            )
             if e:
-                errs.append(f"{r['panel_url']} (template '{r['template_username']}'): {e}")
-            per_panel[r["id"]] = svc or []
+                errs.append(
+                    f"{r['panel_url']} (template '{r['template_username']}'): {e}"
+                )
+            per_panel[r["id"]] = {"service_ids": svc or []}
         else:
-            per_panel[r["id"]] = []
+            tmpl = r.get("template_username")
+            if not tmpl:
+                errs.append(f"{r['panel_url']}: template missing")
+                per_panel[r["id"]] = {"proxies": {}, "inbounds": {}}
+                continue
+            obj, e = api.get_user(r["panel_url"], r["access_token"], tmpl)
+            if not obj:
+                errs.append(
+                    f"{r['panel_url']} (template '{tmpl}'): {e or 'not found'}"
+                )
+                per_panel[r["id"]] = {"proxies": {}, "inbounds": {}}
+                continue
+            per_panel[r["id"]] = {
+                "proxies": obj.get("proxies") or {},
+                "inbounds": obj.get("inbounds") or {},
+            }
     if errs:
-        await q.edit_message_text("❌ خطا در خواندن سرویس بعضی پنل‌ها:\n" + "\n".join(f"• {e}" for e in errs[:10]))
+        await q.edit_message_text(
+            "❌ خطا در خواندن سرویس بعضی پنل‌ها:\n" +
+            "\n".join(f"• {e}" for e in errs[:10])
+        )
         return
-
-    payload_base = {
-        "username": app_username,
-        "expire_strategy": "start_on_first_use",
-        "usage_duration": usage_sec,
-        "data_limit": limit_bytes,
-        "data_limit_reset_strategy": "no_reset",
-        "note": "created_by_bot",
-    }
 
     ok, failed = 0, []
     for r in rows:
         api = get_api(r.get("panel_type"))
-        payload = {**payload_base}
         if r.get("panel_type") == "marzneshin":
-            payload["service_ids"] = per_panel.get(r["id"], [])
+            payload = {
+                "username": app_username,
+                "expire_strategy": "start_on_first_use",
+                "usage_duration": usage_sec,
+                "data_limit": limit_bytes,
+                "data_limit_reset_strategy": "no_reset",
+                "note": "created_by_bot",
+                "service_ids": per_panel.get(r["id"], {}).get("service_ids", []),
+            }
+        else:
+            expire_ts = 0 if usage_sec <= 0 else int(datetime.now(timezone.utc).timestamp()) + usage_sec
+            tmpl_info = per_panel.get(r["id"], {})
+            payload = {
+                "username": app_username,
+                "expire": expire_ts,
+                "data_limit": limit_bytes,
+                "data_limit_reset_strategy": "no_reset",
+                "note": "created_by_bot",
+                "proxies": tmpl_info.get("proxies", {}),
+                "inbounds": tmpl_info.get("inbounds", {}),
+            }
         obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
         if not obj:
             obj, g = api.get_user(r["panel_url"], r["access_token"], app_username)
@@ -1662,14 +1694,11 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
         usage_duration_default = 3650*86400
 
     if to_add:
-        base_payload = {
-            "username": username,
-            "expire_strategy": "start_on_first_use",
-            "usage_duration": usage_duration_default,
-            "data_limit": limit_bytes_default,
-            "data_limit_reset_strategy": "no_reset",
-            "note": "user_edit_add_panel",
-        }
+        expire_ts_default = (
+            0
+            if usage_duration_default <= 0
+            else int(datetime.now(timezone.utc).timestamp()) + usage_duration_default
+        )
         for pid in to_add:
             p = panels_map.get(int(pid))
             if not p:
@@ -1704,7 +1733,15 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
                         added_errs.append(f"{p['panel_url']}: {e}")
                     continue
 
-                payload = {**base_payload, "service_ids": svc or []}
+                payload = {
+                    "username": username,
+                    "expire_strategy": "start_on_first_use",
+                    "usage_duration": usage_duration_default,
+                    "data_limit": limit_bytes_default,
+                    "data_limit_reset_strategy": "no_reset",
+                    "note": "user_edit_add_panel",
+                    "service_ids": svc or [],
+                }
                 obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
                 if not obj:
                     obj, g = api.get_user(p["panel_url"], p["access_token"], username)
@@ -1722,15 +1759,45 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
             else:
                 obj, g = api.get_user(p["panel_url"], p["access_token"], username)
                 if not obj:
-                    payload = {**base_payload}
-                    obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
-                    if not obj:
-                        added_errs.append(f"{p['panel_url']}: {e2 or 'unknown error'}")
+                    if tmpl:
+                        tmpl_obj, t_err = api.get_user(
+                            p["panel_url"], p["access_token"], tmpl
+                        )
+                        if not tmpl_obj:
+                            added_errs.append(
+                                f"{p['panel_url']} (template '{tmpl}'): {t_err or 'not found'}"
+                            )
+                            continue
+                        payload = {
+                            "username": username,
+                            "expire": expire_ts_default,
+                            "data_limit": limit_bytes_default,
+                            "data_limit_reset_strategy": "no_reset",
+                            "note": "user_edit_add_panel",
+                            "proxies": tmpl_obj.get("proxies") or {},
+                            "inbounds": tmpl_obj.get("inbounds") or {},
+                        }
+                        obj, e2 = api.create_user(
+                            p["panel_url"], p["access_token"], payload
+                        )
+                        if not obj:
+                            added_errs.append(
+                                f"{p['panel_url']}: {e2 or 'unknown error'}"
+                            )
+                            continue
+                    else:
+                        added_errs.append(
+                            f"{p['panel_url']}: no template & user not found"
+                        )
                         continue
                 if not obj.get("enabled", True):
-                    ok_en, err_en = api.enable_remote_user(p["panel_url"], p["access_token"], username)
+                    ok_en, err_en = api.enable_remote_user(
+                        p["panel_url"], p["access_token"], username
+                    )
                     if not ok_en:
-                        added_errs.append(f"{p['panel_url']}: enable failed - {err_en or 'unknown'}")
+                        added_errs.append(
+                            f"{p['panel_url']}: enable failed - {err_en or 'unknown'}"
+                        )
                 save_link(owner_id, username, int(pid), username)
                 added_ok += 1
 

--- a/marzban.py
+++ b/marzban.py
@@ -33,7 +33,7 @@ def create_user(panel_url: str, token: str, payload: Dict) -> Tuple[Optional[Dic
             headers={**get_headers(token), "Content-Type": "application/json"},
             timeout=20,
         )
-        if r.status_code == 200:
+        if r.status_code in (200, 201):
             return r.json(), None
         return None, f"{r.status_code} {r.text[:300]}"
     except Exception as e:  # pragma: no cover - network errors

--- a/usage_sync.py
+++ b/usage_sync.py
@@ -7,10 +7,12 @@ import logging
 from urllib.parse import urljoin
 from datetime import datetime, timezone
 
-import requests
 from dotenv import load_dotenv
 from mysql.connector import pooling
 import mysql.connector
+
+import marzneshin
+import marzban
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -19,6 +21,16 @@ logging.basicConfig(
 log = logging.getLogger("usage_sync")
 
 POOL = None
+
+API_MODULES = {
+    "marzneshin": marzneshin,
+    "marzban": marzban,
+}
+
+
+def get_api(panel_type: str):
+    """Return API module for the given panel type."""
+    return API_MODULES.get(panel_type or "marzneshin", marzneshin)
 
 def init_db():
     global POOL
@@ -92,7 +104,8 @@ def fetch_all_links():
                        lup.remote_username,
                        lup.last_used_traffic,
                        p.panel_url,
-                       p.access_token
+                       p.access_token,
+                       p.panel_type
                 FROM local_user_panel_links lup
                 JOIN panels p ON p.id = lup.panel_id
                 ORDER BY lup.id ASC
@@ -106,16 +119,15 @@ def fetch_all_links():
             return []
         raise
 
-def fetch_used_traffic(panel_url, bearer, remote_username):
+def fetch_used_traffic(panel_type, panel_url, bearer, remote_username):
+    """Return used traffic for a remote user via appropriate panel API."""
     try:
-        # Preserve any subpath in panel_url when joining API routes
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
-        r = requests.get(url, headers={"Authorization": f"Bearer {bearer}"}, timeout=20)
-        if r.status_code != 200:
-            return None, f"{panel_url}: {r.status_code} {r.text[:120]}"
-        data = r.json()
-        return int(data.get("used_traffic", 0)), None
-    except Exception as e:
+        api = get_api(panel_type)
+        obj, err = api.get_user(panel_url, bearer, remote_username)
+        if not obj:
+            return None, f"{panel_url}: {err or 'user not found'}"
+        return int(obj.get("used_traffic", 0) or 0), None
+    except Exception as e:  # pragma: no cover - network errors
         return None, str(e)
 
 def add_usage(owner_id, local_username, delta):
@@ -148,7 +160,7 @@ def get_local_user(owner_id, local_username):
 def list_links_of_local_user(owner_id, local_username):
     with CurCtx() as cur:
         cur.execute("""
-            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token
+            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
@@ -163,21 +175,16 @@ def mark_user_disabled(owner_id, local_username):
             WHERE owner_id=%s AND username=%s
         """, (owner_id, local_username))
 
-def disable_remote(panel_url, token, remote_username):
-    try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
-        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
-        return r.status_code, r.text[:200]
-    except Exception as e:
-        return None, str(e)
+def disable_remote(panel_type, panel_url, token, remote_username):
+    api = get_api(panel_type)
+    ok, msg = api.disable_remote_user(panel_url, token, remote_username)
+    return (200 if ok else None), msg
 
-def enable_remote(panel_url, token, remote_username):
-    try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/enable")
-        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
-        return r.status_code, r.text[:200]
-    except Exception as e:
-        return None, str(e)
+
+def enable_remote(panel_type, panel_url, token, remote_username):
+    api = get_api(panel_type)
+    ok, msg = api.enable_remote_user(panel_url, token, remote_username)
+    return (200 if ok else None), msg
 
 def mark_user_enabled(owner_id, local_username):
     with CurCtx() as cur:
@@ -198,7 +205,7 @@ def try_disable_if_user_exceeded(owner_id, local_username):
     if limit > 0 and used >= limit and not pushed:
         links = list_links_of_local_user(owner_id, local_username)
         for l in links:
-            code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+            code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
             if code and code != 200:
                 log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             else:
@@ -216,7 +223,7 @@ def try_enable_if_user_ok(owner_id, local_username):
     if pushed and (limit == 0 or used < limit):
         links = list_links_of_local_user(owner_id, local_username)
         for l in links:
-            code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+            code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
             if code and code != 200:
                 log.warning("enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             else:
@@ -255,7 +262,7 @@ def list_agent_assigned_panels(owner_id: int):
     """پنل‌هایی که به نماینده assign شده‌اند (agent_panels)."""
     with CurCtx() as cur:
         cur.execute("""
-            SELECT p.id, p.panel_url, p.access_token
+            SELECT p.id, p.panel_url, p.access_token, p.panel_type
             FROM agent_panels ap
             JOIN panels p ON p.id = ap.panel_id
             WHERE ap.agent_tg_id=%s
@@ -282,7 +289,7 @@ def disable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username دیزیبل کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = disable_remote(p["panel_url"], p["access_token"], username)
+        code, msg = disable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
         if code and code != 200:
             log.warning("disable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -292,7 +299,7 @@ def enable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username فعال کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = enable_remote(p["panel_url"], p["access_token"], username)
+        code, msg = enable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
         if code and code != 200:
             log.warning("enable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -352,7 +359,7 @@ def try_disable_agent_if_exceeded(owner_id: int):
             # 1) disable روی مپ‌های مستقیم کاربر
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                 if code and code != 200:
                     log.warning("[AGENT] disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -395,7 +402,7 @@ def try_enable_agent_if_ok(owner_id: int):
         for uname in usernames:
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                 if code and code != 200:
                     log.warning("[AGENT] enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -424,7 +431,7 @@ def loop():
             links = fetch_all_links()
             seen_owners = set()
             for row in links:
-                used, err = fetch_used_traffic(row["panel_url"], row["access_token"], row["remote_username"])
+                used, err = fetch_used_traffic(row["panel_type"], row["panel_url"], row["access_token"], row["remote_username"])
                 if used is None:
                     log.warning("fetch_used_traffic failed for %s@%s: %s",
                                 row["remote_username"], row["panel_url"], err)


### PR DESCRIPTION
## Summary
- build Marzban-specific user creation payloads with expire timestamps and default inbounds
- accept HTTP 201 responses from Marzban user creation API
- pull template proxies/inbounds when creating users on Marzban panels to avoid 500 errors
- remove unused requests import

## Testing
- `python -m py_compile usage_sync.py bot.py marzban.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6f5d1cb7483288c696ee96086149d