### PR TITLE
Add Marzban panel support to usage sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Flask subscription aggregator for Marzneshin
+Flask subscription aggregator for Marzneshin and Marzban
 - GET /sub/<local_username>/<app_key>/links
 - Returns only configs (ss://, vless://, vmess://, trojan://), one per line (text/plain)
 - Enforces local quota. If user quota exceeded -> empty body + DISABLE remote (once).
 - NEW: Enforces AGENT-level quota/expiry too: if agent exhausted/expired -> empty body + DISABLE ALL agent users (once).
 - Supports per-panel disabled config-name filters (anything after '#' is the name).
+- Handles Marzban's base64 subscriptions served from /v2ray endpoints.
 """
 
 import os
 import logging
 import re
+import base64
 from urllib.parse import urljoin, unquote
 
 import requests
 from flask import Flask, Response, abort
 from dotenv import load_dotenv
 from mysql.connector import pooling
+
+import marzneshin
+import marzban
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | flask_agg | %(message)s",
@@ -27,6 +32,14 @@ log = logging.getLogger("flask_agg")
 
 POOL = None
 ALLOWED_SCHEMES = ("vless://", "vmess://", "trojan://", "ss://")
+
+API_MODULES = {
+    "marzneshin": marzneshin,
+    "marzban": marzban,
+}
+
+def get_api(panel_type: str):
+    return API_MODULES.get(panel_type or "marzneshin", marzneshin)
 
 def init_pool():
     global POOL
@@ -87,7 +100,7 @@ def list_mapped_links(owner_id, local_username):
         cur.execute(
             """
             SELECT lup.panel_id, lup.remote_username,
-                   p.panel_url, p.access_token
+                   p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
@@ -105,7 +118,7 @@ def list_all_panels(owner_id):
     """
     with CurCtx() as cur:
         cur.execute(
-            "SELECT id, panel_url, access_token FROM panels WHERE telegram_user_id=%s",
+            "SELECT id, panel_url, access_token, panel_type FROM panels WHERE telegram_user_id=%s",
             (owner_id,),
         )
         return cur.fetchall()
@@ -118,42 +131,64 @@ def mark_user_disabled(owner_id, local_username):
             WHERE owner_id=%s AND username=%s
         """, (owner_id, local_username))
 
-def disable_remote(panel_url, token, remote_username):
+def disable_remote(panel_type, panel_url, token, remote_username):
+    api = get_api(panel_type)
     try:
-        # panel_url may already include a path component; urljoin with a leading
-        # slash would discard it. Join paths relative to preserve subpaths.
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
-        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
-        return r.status_code, r.text[:200]
+        ok, msg = api.disable_remote_user(panel_url, token, remote_username)
+        return (200 if ok else None), msg
     except Exception as e:
         return None, str(e)
 
-def fetch_user(panel_url: str, token: str, remote_username: str):
+def fetch_user(panel_type: str, panel_url: str, token: str, remote_username: str):
+    api = get_api(panel_type)
     try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
-        r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
-        if r.status_code != 200:
-            return None
-        return r.json()
-    except:
-        return None
+        obj, err = api.get_user(panel_url, token, remote_username)
+        if obj:
+            return obj
+    except Exception:
+        pass
+    return None
 
 def fetch_links_from_panel(panel_url: str, remote_username: str, key: str):
-    try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"sub/{remote_username}/{key}/links")
-        r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
+    """Fetch subscription configs from a panel.
+
+    Marzban panels expose base64-encoded subscriptions at the ``/v2ray``
+    endpoint only, while Marzneshin panels continue to serve plain-text lists
+    at ``/links``.  We therefore attempt ``/v2ray`` first to properly decode
+    Marzban responses and fall back to ``/links`` for Marzneshin or legacy
+    panels.
+    """
+    paths = ("v2ray", "links")
+    for suffix in paths:
         try:
-            if r.headers.get("content-type","").startswith("application/json"):
-                data = r.json()
-                if isinstance(data, list):
-                    return [str(x) for x in data]
-                if isinstance(data, dict) and "links" in data:
-                    return [str(x) for x in data["links"]]
-        except:
-            pass
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
-    except:
-        return []
+            url = urljoin(panel_url.rstrip("/") + "/", f"sub/{remote_username}/{key}/{suffix}")
+            r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
+            if suffix == "v2ray":
+                text = (r.text or "").strip()
+                if text:
+                    try:
+                        decoded = base64.b64decode(text).decode("utf-8", "ignore")
+                        lines = [ln.strip() for ln in decoded.splitlines() if ln.strip()]
+                        if lines:
+                            return lines
+                    except Exception:
+                        pass
+            else:
+                try:
+                    if r.headers.get("content-type", "").startswith("application/json"):
+                        data = r.json()
+                        if isinstance(data, list):
+                            return [str(x) for x in data]
+                        if isinstance(data, dict) and "links" in data:
+                            return [str(x) for x in data["links"]]
+                except Exception:
+                    pass
+                lines = [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
+                if lines:
+                    return lines
+        except Exception:
+            continue
+    return []
 
 def filter_dedupe(links):
     out, seen = [], set()
@@ -233,7 +268,7 @@ def get_agent_total_used(owner_id: int) -> int:
 def list_all_agent_links(owner_id: int):
     with CurCtx() as cur:
         cur.execute("""
-            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token
+            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s
@@ -272,7 +307,9 @@ def unified_links(local_username, app_key):
             if not pushed_a:
                 # disable ALL users of this agent across all panels (once)
                 for l in list_all_agent_links(owner_id):
-                    code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                    code, msg = disable_remote(
+                        l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"]
+                    )
                     if code and code != 200:
                         log.warning("AGENT disable on %s@%s -> %s %s",
                                     l["remote_username"], l["panel_url"], code, msg)
@@ -293,10 +330,20 @@ def unified_links(local_username, app_key):
             links = list_mapped_links(owner_id, local_username)
             if not links:
                 panels = list_all_panels(owner_id)
-                links = [{"panel_id": p["id"], "remote_username": local_username,
-                          "panel_url": p["panel_url"], "access_token": p["access_token"]} for p in panels]
+                links = [
+                    {
+                        "panel_id": p["id"],
+                        "remote_username": local_username,
+                        "panel_url": p["panel_url"],
+                        "access_token": p["access_token"],
+                        "panel_type": p["panel_type"],
+                    }
+                    for p in panels
+                ]
             for l in links:
-                code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(
+                    l.get("panel_type"), l["panel_url"], l["access_token"], l["remote_username"]
+                )
                 if code and code != 200:
                     log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             mark_user_disabled(owner_id, local_username)
@@ -315,7 +362,7 @@ def unified_links(local_username, app_key):
             disabled_names = get_panel_disabled_names(l["panel_id"])
             disabled_nums = get_panel_disabled_nums(l["panel_id"])
             links = []
-            u = fetch_user(l["panel_url"], l["access_token"], l["remote_username"])
+            u = fetch_user(l.get("panel_type"), l["panel_url"], l["access_token"], l["remote_username"])
             if u and u.get("key"):
                 links = fetch_links_from_panel(
                     l["panel_url"], l["remote_username"], u["key"]
@@ -330,7 +377,7 @@ def unified_links(local_username, app_key):
             disabled_names = get_panel_disabled_names(p["id"])
             disabled_nums = get_panel_disabled_nums(p["id"])
             links = []
-            u = fetch_user(p["panel_url"], p["access_token"], local_username)
+            u = fetch_user(p.get("panel_type"), p["panel_url"], p["access_token"], local_username)
             if u and u.get("key"):
                 links = fetch_links_from_panel(
                     p["panel_url"], local_username, u["key"]

--- a/bot.py
+++ b/bot.py
@@ -35,7 +35,6 @@ from mysql.connector import pooling, Error as MySQLError
 
 import marzneshin
 import marzban
-from marzneshin import fetch_subscription_links
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -1092,7 +1091,7 @@ async def show_panel_cfg_selector(q, context: ContextTypes.DEFAULT_TYPE, owner_i
         if u and u.get("key"):
             links = api.fetch_links_from_panel(info["panel_url"], info["template_username"], u["key"])
     elif info.get("sub_url"):
-        links = fetch_subscription_links(info["sub_url"])
+        links = api.fetch_subscription_links(info["sub_url"])
     if not links:
         await q.edit_message_text("ابتدا template یا لینک سابسکریپشن را تنظیم کن.")
         return ConversationHandler.END
@@ -1131,7 +1130,7 @@ async def show_panel_cfgnum_selector(q, context: ContextTypes.DEFAULT_TYPE, owne
         if u and u.get("key"):
             links = api.fetch_links_from_panel(info["panel_url"], info["template_username"], u["key"])
     elif info.get("sub_url"):
-        links = fetch_subscription_links(info["sub_url"])
+        links = api.fetch_subscription_links(info["sub_url"])
     if not links:
         await q.edit_message_text("ابتدا template یا لینک سابسکریپشن را تنظیم کن.")
         return ConversationHandler.END
@@ -1592,31 +1591,63 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
     for r in rows:
         api = get_api(r.get("panel_type"))
         if r.get("panel_type") == "marzneshin":
-            svc, e = api.fetch_user_services(r["panel_url"], r["access_token"], r.get("template_username"))
+            svc, e = api.fetch_user_services(
+                r["panel_url"], r["access_token"], r.get("template_username")
+            )
             if e:
-                errs.append(f"{r['panel_url']} (template '{r['template_username']}'): {e}")
-            per_panel[r["id"]] = svc or []
+                errs.append(
+                    f"{r['panel_url']} (template '{r['template_username']}'): {e}"
+                )
+            per_panel[r["id"]] = {"service_ids": svc or []}
         else:
-            per_panel[r["id"]] = []
+            tmpl = r.get("template_username")
+            if not tmpl:
+                errs.append(f"{r['panel_url']}: template missing")
+                per_panel[r["id"]] = {"proxies": {}, "inbounds": {}}
+                continue
+            obj, e = api.get_user(r["panel_url"], r["access_token"], tmpl)
+            if not obj:
+                errs.append(
+                    f"{r['panel_url']} (template '{tmpl}'): {e or 'not found'}"
+                )
+                per_panel[r["id"]] = {"proxies": {}, "inbounds": {}}
+                continue
+            per_panel[r["id"]] = {
+                "proxies": obj.get("proxies") or {},
+                "inbounds": obj.get("inbounds") or {},
+            }
     if errs:
-        await q.edit_message_text("❌ خطا در خواندن سرویس بعضی پنل‌ها:\n" + "\n".join(f"• {e}" for e in errs[:10]))
+        await q.edit_message_text(
+            "❌ خطا در خواندن سرویس بعضی پنل‌ها:\n" +
+            "\n".join(f"• {e}" for e in errs[:10])
+        )
         return
-
-    payload_base = {
-        "username": app_username,
-        "expire_strategy": "start_on_first_use",
-        "usage_duration": usage_sec,
-        "data_limit": limit_bytes,
-        "data_limit_reset_strategy": "no_reset",
-        "note": "created_by_bot",
-    }
 
     ok, failed = 0, []
     for r in rows:
         api = get_api(r.get("panel_type"))
-        payload = {**payload_base}
         if r.get("panel_type") == "marzneshin":
-            payload["service_ids"] = per_panel.get(r["id"], [])
+            payload = {
+                "username": app_username,
+                "expire_strategy": "start_on_first_use",
+                "usage_duration": usage_sec,
+                "data_limit": limit_bytes,
+                "data_limit_reset_strategy": "no_reset",
+                "note": "created_by_bot",
+                "service_ids": per_panel.get(r["id"], {}).get("service_ids", []),
+            }
+        else:
+            expire_ts = 0 if usage_sec <= 0 else int(datetime.now(timezone.utc).timestamp()) + usage_sec
+            tmpl_info = per_panel.get(r["id"], {})
+            payload = {
+                "username": app_username,
+                "expire": expire_ts,
+                "data_limit": limit_bytes,
+                "data_limit_reset_strategy": "no_reset",
+                "note": "created_by_bot",
+                "proxies": tmpl_info.get("proxies", {}),
+                "inbounds": tmpl_info.get("inbounds", {}),
+            }
         obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
         if not obj:
             obj, g = api.get_user(r["panel_url"], r["access_token"], app_username)
@@ -1662,14 +1693,11 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
         usage_duration_default = 3650*86400
 
     if to_add:
-        base_payload = {
-            "username": username,
-            "expire_strategy": "start_on_first_use",
-            "usage_duration": usage_duration_default,
-            "data_limit": limit_bytes_default,
-            "data_limit_reset_strategy": "no_reset",
-            "note": "user_edit_add_panel",
-        }
+        expire_ts_default = (
+            0
+            if usage_duration_default <= 0
+            else int(datetime.now(timezone.utc).timestamp()) + usage_duration_default
+        )
         for pid in to_add:
             p = panels_map.get(int(pid))
             if not p:
@@ -1704,7 +1732,15 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
                         added_errs.append(f"{p['panel_url']}: {e}")
                     continue
 
-                payload = {**base_payload, "service_ids": svc or []}
+                payload = {
+                    "username": username,
+                    "expire_strategy": "start_on_first_use",
+                    "usage_duration": usage_duration_default,
+                    "data_limit": limit_bytes_default,
+                    "data_limit_reset_strategy": "no_reset",
+                    "note": "user_edit_add_panel",
+                    "service_ids": svc or [],
+                }
                 obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
                 if not obj:
                     obj, g = api.get_user(p["panel_url"], p["access_token"], username)
@@ -1722,15 +1758,45 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
             else:
                 obj, g = api.get_user(p["panel_url"], p["access_token"], username)
                 if not obj:
-                    payload = {**base_payload}
-                    obj, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
-                    if not obj:
-                        added_errs.append(f"{p['panel_url']}: {e2 or 'unknown error'}")
+                    if tmpl:
+                        tmpl_obj, t_err = api.get_user(
+                            p["panel_url"], p["access_token"], tmpl
+                        )
+                        if not tmpl_obj:
+                            added_errs.append(
+                                f"{p['panel_url']} (template '{tmpl}'): {t_err or 'not found'}"
+                            )
+                            continue
+                        payload = {
+                            "username": username,
+                            "expire": expire_ts_default,
+                            "data_limit": limit_bytes_default,
+                            "data_limit_reset_strategy": "no_reset",
+                            "note": "user_edit_add_panel",
+                            "proxies": tmpl_obj.get("proxies") or {},
+                            "inbounds": tmpl_obj.get("inbounds") or {},
+                        }
+                        obj, e2 = api.create_user(
+                            p["panel_url"], p["access_token"], payload
+                        )
+                        if not obj:
+                            added_errs.append(
+                                f"{p['panel_url']}: {e2 or 'unknown error'}"
+                            )
+                            continue
+                    else:
+                        added_errs.append(
+                            f"{p['panel_url']}: no template & user not found"
+                        )
                         continue
                 if not obj.get("enabled", True):
-                    ok_en, err_en = api.enable_remote_user(p["panel_url"], p["access_token"], username)
+                    ok_en, err_en = api.enable_remote_user(
+                        p["panel_url"], p["access_token"], username
+                    )
                     if not ok_en:
-                        added_errs.append(f"{p['panel_url']}: enable failed - {err_en or 'unknown'}")
+                        added_errs.append(
+                            f"{p['panel_url']}: enable failed - {err_en or 'unknown'}"
+                        )
                 save_link(owner_id, username, int(pid), username)
                 added_ok += 1
 

--- a/marzban.py
+++ b/marzban.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
+import base64
 import requests
 
 
@@ -33,7 +34,7 @@ def create_user(panel_url: str, token: str, payload: Dict) -> Tuple[Optional[Dic
             headers={**get_headers(token), "Content-Type": "application/json"},
             timeout=20,
         )
-        if r.status_code == 200:
+        if r.status_code in (200, 201):
             return r.json(), None
         return None, f"{r.status_code} {r.text[:300]}"
     except Exception as e:  # pragma: no cover - network errors
@@ -64,22 +65,28 @@ def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict],
 
 
 def fetch_links_from_panel(panel_url: str, username: str, key: str) -> List[str]:
-    """Return list of subscription links for a user token."""
+    """Return list of subscription links for a user token.
+
+    Marzban serves subscriptions as base64 strings via the ``/v2ray`` path, so
+    we attempt to fetch that endpoint and decode the contents.  No other format
+    is currently supported, but the function gracefully returns an empty list on
+    failure.
+    """
     try:
-        url = urljoin(panel_url.rstrip('/') + '/', f"sub/{key}/")
+        url = urljoin(
+            panel_url.rstrip('/') + '/', f"sub/{username}/{key}/v2ray"
+        )
         r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
-        try:
-            if r.headers.get("content-type", "").startswith("application/json"):
-                data = r.json()
-                if isinstance(data, list):
-                    return [str(x) for x in data]
-                if isinstance(data, dict) and "links" in data:
-                    return [str(x) for x in data["links"]]
-        except Exception:  # pragma: no cover - parsing errors
-            pass
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
+        text = (r.text or "").strip()
+        if text:
+            try:
+                decoded = base64.b64decode(text).decode("utf-8", "ignore")
+                return [ln.strip() for ln in decoded.splitlines() if ln.strip()]
+            except Exception:
+                pass
     except Exception:  # pragma: no cover - network errors
-        return []
+        pass
+    return []
 
 
 def disable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
@@ -115,16 +122,28 @@ def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
 
 
 def fetch_subscription_links(sub_url: str) -> List[str]:
-    """Return links from a subscription URL."""
+    """Return links from a subscription URL.
+
+    Marzban subscriptions returned from ``/v2ray`` endpoints are base64
+    encoded.  We first attempt to decode the body as base64 and fall back to
+    treating it as plain text if decoding fails.
+    """
     try:
         r = requests.get(sub_url, headers={"accept": "text/plain,application/json"}, timeout=20)
+        text = (r.text or "").strip()
         if r.headers.get("content-type", "").startswith("application/json"):
             data = r.json()
             if isinstance(data, list):
                 return [str(x) for x in data]
             if isinstance(data, dict) and "links" in data:
                 return [str(x) for x in data["links"]]
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
+        if text:
+            try:
+                decoded = base64.b64decode(text).decode("utf-8", "ignore")
+                return [ln.strip() for ln in decoded.splitlines() if ln.strip()]
+            except Exception:
+                pass
+        return [ln.strip() for ln in text.splitlines() if ln.strip()]
     except Exception:  # pragma: no cover - network errors
         return []
 

--- a/usage_sync.py
+++ b/usage_sync.py
@@ -7,10 +7,12 @@ import logging
 from urllib.parse import urljoin
 from datetime import datetime, timezone
 
-import requests
 from dotenv import load_dotenv
 from mysql.connector import pooling
 import mysql.connector
+
+import marzneshin
+import marzban
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -19,6 +21,16 @@ logging.basicConfig(
 log = logging.getLogger("usage_sync")
 
 POOL = None
+
+API_MODULES = {
+    "marzneshin": marzneshin,
+    "marzban": marzban,
+}
+
+
+def get_api(panel_type: str):
+    """Return API module for the given panel type."""
+    return API_MODULES.get(panel_type or "marzneshin", marzneshin)
 
 def init_db():
     global POOL
@@ -92,7 +104,8 @@ def fetch_all_links():
                        lup.remote_username,
                        lup.last_used_traffic,
                        p.panel_url,
-                       p.access_token
+                       p.access_token,
+                       p.panel_type
                 FROM local_user_panel_links lup
                 JOIN panels p ON p.id = lup.panel_id
                 ORDER BY lup.id ASC
@@ -106,16 +119,15 @@ def fetch_all_links():
             return []
         raise
 
-def fetch_used_traffic(panel_url, bearer, remote_username):
+def fetch_used_traffic(panel_type, panel_url, bearer, remote_username):
+    """Return used traffic for a remote user via appropriate panel API."""
     try:
-        # Preserve any subpath in panel_url when joining API routes
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
-        r = requests.get(url, headers={"Authorization": f"Bearer {bearer}"}, timeout=20)
-        if r.status_code != 200:
-            return None, f"{panel_url}: {r.status_code} {r.text[:120]}"
-        data = r.json()
-        return int(data.get("used_traffic", 0)), None
-    except Exception as e:
+        api = get_api(panel_type)
+        obj, err = api.get_user(panel_url, bearer, remote_username)
+        if not obj:
+            return None, f"{panel_url}: {err or 'user not found'}"
+        return int(obj.get("used_traffic", 0) or 0), None
+    except Exception as e:  # pragma: no cover - network errors
         return None, str(e)
 
 def add_usage(owner_id, local_username, delta):
@@ -148,7 +160,7 @@ def get_local_user(owner_id, local_username):
 def list_links_of_local_user(owner_id, local_username):
     with CurCtx() as cur:
         cur.execute("""
-            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token
+            SELECT lup.panel_id, lup.remote_username, p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
@@ -163,21 +175,16 @@ def mark_user_disabled(owner_id, local_username):
             WHERE owner_id=%s AND username=%s
         """, (owner_id, local_username))
 
-def disable_remote(panel_url, token, remote_username):
-    try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
-        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
-        return r.status_code, r.text[:200]
-    except Exception as e:
-        return None, str(e)
+def disable_remote(panel_type, panel_url, token, remote_username):
+    api = get_api(panel_type)
+    ok, msg = api.disable_remote_user(panel_url, token, remote_username)
+    return (200 if ok else None), msg
 
-def enable_remote(panel_url, token, remote_username):
-    try:
-        url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/enable")
-        r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
-        return r.status_code, r.text[:200]
-    except Exception as e:
-        return None, str(e)
+
+def enable_remote(panel_type, panel_url, token, remote_username):
+    api = get_api(panel_type)
+    ok, msg = api.enable_remote_user(panel_url, token, remote_username)
+    return (200 if ok else None), msg
 
 def mark_user_enabled(owner_id, local_username):
     with CurCtx() as cur:
@@ -198,7 +205,7 @@ def try_disable_if_user_exceeded(owner_id, local_username):
     if limit > 0 and used >= limit and not pushed:
         links = list_links_of_local_user(owner_id, local_username)
         for l in links:
-            code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+            code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
             if code and code != 200:
                 log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             else:
@@ -216,7 +223,7 @@ def try_enable_if_user_ok(owner_id, local_username):
     if pushed and (limit == 0 or used < limit):
         links = list_links_of_local_user(owner_id, local_username)
         for l in links:
-            code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+            code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
             if code and code != 200:
                 log.warning("enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             else:
@@ -255,7 +262,7 @@ def list_agent_assigned_panels(owner_id: int):
     """پنل‌هایی که به نماینده assign شده‌اند (agent_panels)."""
     with CurCtx() as cur:
         cur.execute("""
-            SELECT p.id, p.panel_url, p.access_token
+            SELECT p.id, p.panel_url, p.access_token, p.panel_type
             FROM agent_panels ap
             JOIN panels p ON p.id = ap.panel_id
             WHERE ap.agent_tg_id=%s
@@ -282,7 +289,7 @@ def disable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username دیزیبل کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = disable_remote(p["panel_url"], p["access_token"], username)
+        code, msg = disable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
         if code and code != 200:
             log.warning("disable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -292,7 +299,7 @@ def enable_user_on_assigned_panels(owner_id: int, username: str):
     """اگر مپ مستقیمی نبود، روی پنل‌های assign‌شده هم با همان username فعال کن."""
     panels = list_agent_assigned_panels(owner_id)
     for p in panels:
-        code, msg = enable_remote(p["panel_url"], p["access_token"], username)
+        code, msg = enable_remote(p["panel_type"], p["panel_url"], p["access_token"], username)
         if code and code != 200:
             log.warning("enable (assigned) on %s@%s -> %s %s", username, p["panel_url"], code, msg)
         else:
@@ -352,7 +359,7 @@ def try_disable_agent_if_exceeded(owner_id: int):
             # 1) disable روی مپ‌های مستقیم کاربر
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                 if code and code != 200:
                     log.warning("[AGENT] disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -395,7 +402,7 @@ def try_enable_agent_if_ok(owner_id: int):
         for uname in usernames:
             links = list_links_of_local_user(owner_id, uname)
             for l in links:
-                code, msg = enable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = enable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                 if code and code != 200:
                     log.warning("[AGENT] enable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
                 else:
@@ -424,7 +431,7 @@ def loop():
             links = fetch_all_links()
             seen_owners = set()
             for row in links:
-                used, err = fetch_used_traffic(row["panel_url"], row["access_token"], row["remote_username"])
+                used, err = fetch_used_traffic(row["panel_type"], row["panel_url"], row["access_token"], row["remote_username"])
                 if used is None:
                     log.warning("fetch_used_traffic failed for %s@%s: %s",
                                 row["remote_username"], row["panel_url"], err)


### PR DESCRIPTION
## Summary
- track panel types in the subscription aggregator and route user lookups/disable calls through the proper API
- base64-decode Marzban subscriptions served from /v2ray endpoints for templates and direct subscription URLs
- fetch sub-url configs via panel-type-aware helpers so name filtering works for Marzban panels

## Testing
- `python -m py_compile usage_sync.py bot.py marzban.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6f5d1cb7483288c696ee96086149d