### PR TITLE
Handle Marzban v2ray subscription links

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Flask subscription aggregator for Marzneshin
+Flask subscription aggregator for Marzneshin/Marzban panels
 - GET /sub/<local_username>/<app_key>/links
 - Returns only configs (ss://, vless://, vmess://, trojan://), one per line (text/plain)
 - Enforces local quota. If user quota exceeded -> empty body + DISABLE remote (once).
@@ -14,6 +14,7 @@ import logging
 import re
 from urllib.parse import urljoin, unquote
 
+import base64
 import requests
 from flask import Flask, Response, abort
 from dotenv import load_dotenv
@@ -120,10 +121,19 @@ def mark_user_disabled(owner_id, local_username):
 
 def disable_remote(panel_url, token, remote_username):
     try:
-        # panel_url may already include a path component; urljoin with a leading
-        # slash would discard it. Join paths relative to preserve subpaths.
+        # Try Marzneshin style first
         url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
         r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
+        if r.status_code == 200:
+            return r.status_code, r.text[:200]
+        # Fallback to Marzban style
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/user/{remote_username}")
+        r = requests.put(
+            url,
+            json={"status": "disabled"},
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            timeout=20,
+        )
         return r.status_code, r.text[:200]
     except Exception as e:
         return None, str(e)
@@ -132,27 +142,61 @@ def fetch_user(panel_url: str, token: str, remote_username: str):
     try:
         url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}")
         r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
+        if r.status_code == 200:
+            return r.json()
+        # Fallback to Marzban endpoint
+        url = urljoin(panel_url.rstrip("/") + "/", f"api/user/{remote_username}")
+        r = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=15)
         if r.status_code != 200:
             return None
-        return r.json()
+        obj = r.json()
+        status = obj.get("status")
+        obj["enabled"] = status != "disabled"
+        sub_url = obj.get("subscription_url") or ""
+        token_part = sub_url.rstrip("/").split("/")[-1]
+        if token_part:
+            obj.setdefault("key", token_part)
+        return obj
     except:
         return None
 
 def fetch_links_from_panel(panel_url: str, remote_username: str, key: str):
     try:
+        # Try Marzban style first (/v2ray base64)
+        url = urljoin(panel_url.rstrip("/") + "/", f"sub/{key}/v2ray")
+        r = requests.get(url, headers={"accept": "text/plain"}, timeout=20)
+        if r.status_code == 200:
+            txt = (r.text or "").strip()
+            if txt:
+                try:
+                    decoded = base64.b64decode(txt + "===")
+                    txt = decoded.decode(errors="ignore")
+                except Exception:
+                    pass
+                lines = [ln.strip() for ln in txt.splitlines() if ln.strip()]
+                if any(ln.lower().startswith(ALLOWED_SCHEMES) for ln in lines):
+                    return lines
+
+        # Fallback to Marzneshin style
         url = urljoin(panel_url.rstrip("/") + "/", f"sub/{remote_username}/{key}/links")
-        r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
+        r = requests.get(url, headers={"accept": "application/json,text/plain"}, timeout=20)
+        if r.status_code != 200:
+            return []
         try:
-            if r.headers.get("content-type","").startswith("application/json"):
+            if r.headers.get("content-type", "").startswith("application/json"):
                 data = r.json()
                 if isinstance(data, list):
                     return [str(x) for x in data]
                 if isinstance(data, dict) and "links" in data:
                     return [str(x) for x in data["links"]]
-        except:
+        except Exception:
             pass
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
-    except:
+        return [
+            ln.strip()
+            for ln in (r.text or "").splitlines()
+            if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+        ]
+    except Exception:
         return []
 
 def filter_dedupe(links):

--- a/bot.py
+++ b/bot.py
@@ -35,7 +35,6 @@ from mysql.connector import pooling, Error as MySQLError
 
 import marzneshin
 import marzban
-from marzneshin import fetch_subscription_links
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -1092,7 +1091,7 @@ async def show_panel_cfg_selector(q, context: ContextTypes.DEFAULT_TYPE, owner_i
         if u and u.get("key"):
             links = api.fetch_links_from_panel(info["panel_url"], info["template_username"], u["key"])
     elif info.get("sub_url"):
-        links = fetch_subscription_links(info["sub_url"])
+        links = api.fetch_subscription_links(info["sub_url"])
     if not links:
         await q.edit_message_text("ابتدا template یا لینک سابسکریپشن را تنظیم کن.")
         return ConversationHandler.END
@@ -1131,7 +1130,7 @@ async def show_panel_cfgnum_selector(q, context: ContextTypes.DEFAULT_TYPE, owne
         if u and u.get("key"):
             links = api.fetch_links_from_panel(info["panel_url"], info["template_username"], u["key"])
     elif info.get("sub_url"):
-        links = fetch_subscription_links(info["sub_url"])
+        links = api.fetch_subscription_links(info["sub_url"])
     if not links:
         await q.edit_message_text("ابتدا template یا لینک سابسکریپشن را تنظیم کن.")
         return ConversationHandler.END

--- a/marzban.py
+++ b/marzban.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
+import base64
 import requests
+
+ALLOWED_SCHEMES = ("vless://", "vmess://", "trojan://", "ss://")
 
 
 def get_headers(token: str) -> Dict[str, str]:
@@ -64,10 +67,33 @@ def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict],
 
 
 def fetch_links_from_panel(panel_url: str, username: str, key: str) -> List[str]:
-    """Return list of subscription links for a user token."""
+    """Return list of subscription links for a user token.
+
+    Newer Marzban versions expose ``/v2ray`` which returns a base64 encoded
+    blob of newline separated configs.  Older versions returned plain text at
+    ``/sub/<key>/``.  Try the new endpoint first and fall back to the old one
+    for compatibility.
+    """
     try:
+        url = urljoin(panel_url.rstrip('/') + '/', f"sub/{key}/v2ray")
+        r = requests.get(url, headers={"accept": "text/plain"}, timeout=20)
+        if r.status_code == 200:
+            txt = (r.text or "").strip()
+            if txt:
+                try:
+                    decoded = base64.b64decode(txt + "===")
+                    txt = decoded.decode(errors="ignore")
+                except Exception:
+                    pass
+                lines = [ln.strip() for ln in txt.splitlines() if ln.strip()]
+                if any(ln.lower().startswith(ALLOWED_SCHEMES) for ln in lines):
+                    return lines
+
+        # Fallback to legacy plain-text endpoint
         url = urljoin(panel_url.rstrip('/') + '/', f"sub/{key}/")
-        r = requests.get(url, headers={"accept": "application/json"}, timeout=20)
+        r = requests.get(url, headers={"accept": "application/json,text/plain"}, timeout=20)
+        if r.status_code != 200:
+            return []
         try:
             if r.headers.get("content-type", "").startswith("application/json"):
                 data = r.json()
@@ -77,7 +103,11 @@ def fetch_links_from_panel(panel_url: str, username: str, key: str) -> List[str]
                     return [str(x) for x in data["links"]]
         except Exception:  # pragma: no cover - parsing errors
             pass
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
+        return [
+            ln.strip()
+            for ln in (r.text or "").splitlines()
+            if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+        ]
     except Exception:  # pragma: no cover - network errors
         return []
 
@@ -115,16 +145,36 @@ def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
 
 
 def fetch_subscription_links(sub_url: str) -> List[str]:
-    """Return links from a subscription URL."""
+    """Return links from a subscription URL.
+
+    Handles both plain-text lists and base64 encoded blobs returned by the
+    ``/v2ray`` endpoint.
+    """
     try:
         r = requests.get(sub_url, headers={"accept": "text/plain,application/json"}, timeout=20)
+        if r.status_code != 200:
+            return []
+        txt = r.text or ""
         if r.headers.get("content-type", "").startswith("application/json"):
-            data = r.json()
-            if isinstance(data, list):
-                return [str(x) for x in data]
-            if isinstance(data, dict) and "links" in data:
-                return [str(x) for x in data["links"]]
-        return [ln.strip() for ln in (r.text or "").splitlines() if ln.strip()]
+            try:
+                data = r.json()
+                if isinstance(data, list):
+                    return [str(x) for x in data]
+                if isinstance(data, dict) and "links" in data:
+                    return [str(x) for x in data["links"]]
+            except Exception:  # pragma: no cover - parsing errors
+                pass
+        else:
+            try:
+                decoded = base64.b64decode(txt.strip() + "===")
+                txt = decoded.decode(errors="ignore")
+            except Exception:
+                pass
+        return [
+            ln.strip()
+            for ln in txt.splitlines()
+            if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+        ]
     except Exception:  # pragma: no cover - network errors
         return []
 


### PR DESCRIPTION
## Summary
- fetch links from Marzban panels by decoding `/v2ray` base64 blobs and only accept valid schemes before falling back
- validate Marzban helper responses and template subscriptions using allowed-scheme checks

## Testing
- `python -m py_compile app.py bot.py marzban.py`
- `curl http://194.120.116.73/sub/aGFzZmRoYXNmLDE3NTY4MjcyMzIA0kXAsuGcI/v2ray` *(403 Domain forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_68b70bd09fec8328ab8548e375de27a4