### PR TITLE
Support multi-inbound client creation for 3x-ui

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ import requests
 from flask import Flask, Response, abort
 from dotenv import load_dotenv
 from mysql.connector import pooling
+import sanaei
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | flask_agg | %(message)s",
@@ -88,7 +89,7 @@ def list_mapped_links(owner_id, local_username):
         cur.execute(
             """
             SELECT lup.panel_id, lup.remote_username,
-                   p.panel_url, p.access_token
+                   p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s AND lup.local_username=%s
@@ -106,7 +107,7 @@ def list_all_panels(owner_id):
     """
     with CurCtx() as cur:
         cur.execute(
-            "SELECT id, panel_url, access_token FROM panels WHERE telegram_user_id=%s",
+            "SELECT id, panel_url, access_token, panel_type FROM panels WHERE telegram_user_id=%s",
             (owner_id,),
         )
         return cur.fetchall()
@@ -119,8 +120,11 @@ def mark_user_disabled(owner_id, local_username):
             WHERE owner_id=%s AND username=%s
         """, (owner_id, local_username))
 
-def disable_remote(panel_url, token, remote_username):
+def disable_remote(panel_type, panel_url, token, remote_username):
     try:
+        if panel_type == "sanaei":
+            ok, msg = sanaei.disable_remote_user(panel_url, token, remote_username)
+            return (200 if ok else None), msg
         # Try Marzneshin style first
         url = urljoin(panel_url.rstrip("/") + "/", f"api/users/{remote_username}/disable")
         r = requests.post(url, headers={"Authorization": f"Bearer {token}"}, timeout=20)
@@ -289,7 +293,7 @@ def get_agent_total_used(owner_id: int) -> int:
 def list_all_agent_links(owner_id: int):
     with CurCtx() as cur:
         cur.execute("""
-            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token
+            SELECT lup.local_username, lup.remote_username, p.panel_url, p.access_token, p.panel_type
             FROM local_user_panel_links lup
             JOIN panels p ON p.id = lup.panel_id
             WHERE lup.owner_id=%s
@@ -328,7 +332,7 @@ def unified_links(local_username, app_key):
             if not pushed_a:
                 # disable ALL users of this agent across all panels (once)
                 for l in list_all_agent_links(owner_id):
-                    code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                    code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                     if code and code != 200:
                         log.warning("AGENT disable on %s@%s -> %s %s",
                                     l["remote_username"], l["panel_url"], code, msg)
@@ -350,9 +354,10 @@ def unified_links(local_username, app_key):
             if not links:
                 panels = list_all_panels(owner_id)
                 links = [{"panel_id": p["id"], "remote_username": local_username,
-                          "panel_url": p["panel_url"], "access_token": p["access_token"]} for p in panels]
+                          "panel_url": p["panel_url"], "access_token": p["access_token"],
+                          "panel_type": p["panel_type"]} for p in panels]
             for l in links:
-                code, msg = disable_remote(l["panel_url"], l["access_token"], l["remote_username"])
+                code, msg = disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
                 if code and code != 200:
                     log.warning("disable on %s@%s -> %s %s", l["remote_username"], l["panel_url"], code, msg)
             mark_user_disabled(owner_id, local_username)
@@ -368,15 +373,23 @@ def unified_links(local_username, app_key):
     all_links, errors = [], []
     if mapped:
         for l in mapped:
-            disabled_names = get_panel_disabled_names(l["panel_id"])
-            disabled_nums = get_panel_disabled_nums(l["panel_id"])
+            if l.get("panel_type") == "sanaei":
+                disabled_names, disabled_nums = set(), set()
+            else:
+                disabled_names = get_panel_disabled_names(l["panel_id"])
+                disabled_nums = get_panel_disabled_nums(l["panel_id"])
             links = []
             err = None
-            u = fetch_user(l["panel_url"], l["access_token"], l["remote_username"])
-            if u and u.get("key"):
-                links, err = fetch_links_from_panel(
-                    l["panel_url"], l["remote_username"], u["key"]
+            if l.get("panel_type") == "sanaei":
+                links, err = sanaei.fetch_links_from_panel(
+                    l["panel_url"], l["access_token"], l["remote_username"]
                 )
+            else:
+                u = fetch_user(l["panel_url"], l["access_token"], l["remote_username"])
+                if u and u.get("key"):
+                    links, err = fetch_links_from_panel(
+                        l["panel_url"], l["remote_username"], u["key"]
+                    )
             if err:
                 log.warning("fetch %s@%s -> %s", l["remote_username"], l["panel_url"], err)
                 errors.append(f"{l['remote_username']}@{l['panel_url']}: {err}")
@@ -387,15 +400,23 @@ def unified_links(local_username, app_key):
             all_links.extend(links)
     else:
         for p in list_all_panels(owner_id):
-            disabled_names = get_panel_disabled_names(p["id"])
-            disabled_nums = get_panel_disabled_nums(p["id"])
+            if p.get("panel_type") == "sanaei":
+                disabled_names, disabled_nums = set(), set()
+            else:
+                disabled_names = get_panel_disabled_names(p["id"])
+                disabled_nums = get_panel_disabled_nums(p["id"])
             links = []
             err = None
-            u = fetch_user(p["panel_url"], p["access_token"], local_username)
-            if u and u.get("key"):
-                links, err = fetch_links_from_panel(
-                    p["panel_url"], local_username, u["key"]
+            if p.get("panel_type") == "sanaei":
+                links, err = sanaei.fetch_links_from_panel(
+                    p["panel_url"], p["access_token"], local_username
                 )
+            else:
+                u = fetch_user(p["panel_url"], p["access_token"], local_username)
+                if u and u.get("key"):
+                    links, err = fetch_links_from_panel(
+                        p["panel_url"], local_username, u["key"]
+                    )
             if err:
                 log.warning("fetch %s@%s -> %s", local_username, p["panel_url"], err)
                 errors.append(f"{local_username}@{p['panel_url']}: {err}")

--- a/bot.py
+++ b/bot.py
@@ -27,14 +27,19 @@ import os
 import logging
 import secrets
 import re
+import json
+import uuid
 from urllib.parse import urlparse, unquote
 from datetime import datetime, timedelta, timezone
+
+from typing import List
 
 from dotenv import load_dotenv
 from mysql.connector import pooling, Error as MySQLError
 
 import marzneshin
 import marzban
+import sanaei
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -55,6 +60,7 @@ log = logging.getLogger("marz_bot")
 API_MODULES = {
     "marzneshin": marzneshin,
     "marzban": marzban,
+    "sanaei": sanaei,
 }
 
 def get_api(panel_type: str):
@@ -638,9 +644,12 @@ async def show_panel_select(update_or_q, context, owner_id: int, mode: str, user
         return ConversationHandler.END
 
     if mode == "create":
-        panels = [p for p in panels if p.get("template_username")]
+        panels = [
+            p for p in panels
+            if not ((p.get("panel_type") in ("marzneshin", "sanaei")) and not p.get("template_username"))
+        ]
         if not panels:
-            txt = "⚠️ هیچ پنلی template ندارد. از 🛠️ Manage Panels تنظیم کن."
+            txt = "⚠️ هیچ پنلی template/inbound ندارد. از 🛠️ Manage Panels تنظیم کن."
             if hasattr(update_or_q, "edit_message_text"):
                 await update_or_q.edit_message_text(txt)
             else:
@@ -705,7 +714,14 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if data == "p_set_template":
         if not is_admin(uid): return ConversationHandler.END
-        await q.edit_message_text("نام تمپلیت را بفرست (برای حذف، '-'):") ; return ASK_PANEL_TEMPLATE
+        pid = context.user_data.get("edit_panel_id")
+        info = get_panel(uid, pid) if pid else None
+        prompt = (
+            "ID اینباند(ها) را با ویرگول جدا کن"
+            if info and info.get("panel_type") == "sanaei"
+            else "نام تمپلیت"
+        )
+        await q.edit_message_text(f"{prompt} را بفرست (برای حذف، '-'):") ; return ASK_PANEL_TEMPLATE
     if data == "p_rename":
         if not is_admin(uid): return ConversationHandler.END
         await q.edit_message_text("اسم جدید پنل را بفرست:") ; return ASK_EDIT_PANEL_NAME
@@ -713,25 +729,43 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not is_admin(uid): return ConversationHandler.END
         await q.edit_message_text("یوزرنیم ادمین جدید را بفرست:") ; return ASK_EDIT_PANEL_USER
     if data == "p_set_sub":
-        if not is_admin(uid): return ConversationHandler.END
-        await q.edit_message_text("لینک سابسکریپشن پنل را بفرست (برای حذف، '-'):") ; return ASK_PANEL_SUB_URL
-    if data == "p_filter_cfgs":
-        if not is_admin(uid): return ConversationHandler.END
+        if not is_admin(uid):
+            return ConversationHandler.END
         pid = context.user_data.get("edit_panel_id")
         info = get_panel(uid, pid)
         if not info:
             await q.edit_message_text("پنل پیدا نشد.")
+            return ConversationHandler.END
+        if info.get("panel_type") == "sanaei":
+            await q.edit_message_text("این قابلیت برای پنل‌های 3x-ui در دسترس نیست.")
+            return ConversationHandler.END
+        await q.edit_message_text("لینک سابسکریپشن پنل را بفرست (برای حذف، '-'):")
+        return ASK_PANEL_SUB_URL
+    if data == "p_filter_cfgs":
+        if not is_admin(uid):
+            return ConversationHandler.END
+        pid = context.user_data.get("edit_panel_id")
+        info = get_panel(uid, pid)
+        if not info:
+            await q.edit_message_text("پنل پیدا نشد.")
+            return ConversationHandler.END
+        if info.get("panel_type") == "sanaei":
+            await q.edit_message_text("فیلتر کانفیگ برای پنل‌های 3x-ui پشتیبانی نمی‌شود.")
             return ConversationHandler.END
         if not info.get("sub_url"):
             await q.edit_message_text("اول لینک سابسکریپشن پنل را تنظیم کن (Set/Clear Sub URL).")
             return ConversationHandler.END
         return await show_panel_cfg_selector(q, context, uid, pid, page=0)
     if data == "p_filter_cfgnums":
-        if not is_admin(uid): return ConversationHandler.END
+        if not is_admin(uid):
+            return ConversationHandler.END
         pid = context.user_data.get("edit_panel_id")
         info = get_panel(uid, pid)
         if not info:
             await q.edit_message_text("پنل پیدا نشد.")
+            return ConversationHandler.END
+        if info.get("panel_type") == "sanaei":
+            await q.edit_message_text("فیلتر کانفیگ برای پنل‌های 3x-ui پشتیبانی نمی‌شود.")
             return ConversationHandler.END
         if not info.get("sub_url"):
             await q.edit_message_text("اول لینک سابسکریپشن پنل را تنظیم کن (Set/Clear Sub URL).")
@@ -1157,26 +1191,34 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
         await q.edit_message_text("پنل پیدا نشد.")
         return ConversationHandler.END
 
+    is_sanaei = p.get('panel_type') == 'sanaei'
+    label = "Inbound" if is_sanaei else "Template"
     lines = [
         f"🧩 <b>{p['name']}</b>",
         f"📦 Type: <b>{p.get('panel_type', 'marzneshin')}</b>",
         f"🌐 URL: <code>{p['panel_url']}</code>",
         f"👤 Admin: <code>{p['admin_username']}</code>",
-        f"🧬 Template: <b>{p.get('template_username') or '-'}</b>",
-        f"🔗 Sub URL: <code>{p.get('sub_url') or '-'}</code>",
-        "",
-        "چه کاری انجام بدهم؟",
+        f"🧬 {label}: <b>{p.get('template_username') or '-'}</b>",
     ]
+    if not is_sanaei:
+        lines.append(f"🔗 Sub URL: <code>{p.get('sub_url') or '-'}</code>")
+    lines.extend(["", "چه کاری انجام بدهم؟"])
+
     kb = [
-        [InlineKeyboardButton("🧬 Set/Clear Template", callback_data="p_set_template")],
+        [InlineKeyboardButton(f"🧬 Set/Clear {label}", callback_data="p_set_template")],
         [InlineKeyboardButton("🔑 Change Admin Credentials", callback_data="p_change_creds")],
         [InlineKeyboardButton("✏️ Rename Panel", callback_data="p_rename")],
-        [InlineKeyboardButton("🔗 Set/Clear Sub URL", callback_data="p_set_sub")],
-        [InlineKeyboardButton("🧷 فیلتر کانفیگ‌های پنل", callback_data="p_filter_cfgs")],
-        [InlineKeyboardButton("🔢 فیلتر بر اساس شماره", callback_data="p_filter_cfgnums")],
+    ]
+    if not is_sanaei:
+        kb.extend([
+            [InlineKeyboardButton("🔗 Set/Clear Sub URL", callback_data="p_set_sub")],
+            [InlineKeyboardButton("🧷 فیلتر کانفیگ‌های پنل", callback_data="p_filter_cfgs")],
+            [InlineKeyboardButton("🔢 فیلتر بر اساس شماره", callback_data="p_filter_cfgnums")],
+        ])
+    kb.extend([
         [InlineKeyboardButton("🗑️ Remove Panel", callback_data="p_remove")],
         [InlineKeyboardButton("⬅️ Back", callback_data="manage_panels")],
-    ]
+    ])
     await q.edit_message_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
     return ConversationHandler.END
 
@@ -1268,15 +1310,15 @@ async def got_panel_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("❌ اسم معتبر بفرست:")
         return ASK_PANEL_NAME
     context.user_data["panel_name"] = name
-    await update.message.reply_text("نوع پنل را مشخص کن (marzneshin/marzban):")
+    await update.message.reply_text("نوع پنل را مشخص کن (marzneshin/marzban/sanaei):")
     return ASK_PANEL_TYPE
 
 async def got_panel_type(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
         return ConversationHandler.END
     t = (update.message.text or "").strip().lower()
-    if t not in ("marzneshin", "marzban"):
-        await update.message.reply_text("❌ نوع پنل نامعتبر. marzneshin یا marzban بفرست:")
+    if t not in ("marzneshin", "marzban", "sanaei"):
+        await update.message.reply_text("❌ نوع پنل نامعتبر. یکی از marzneshin/marzban/sanaei بفرست:")
         return ASK_PANEL_TYPE
     context.user_data["panel_type"] = t
     await update.message.reply_text("🌐 URL پنل (مثال https://panel.example.com):")
@@ -1344,7 +1386,11 @@ async def got_panel_template(update: Update, context: ContextTypes.DEFAULT_TYPE)
         await update.message.reply_text("❌ پنل انتخاب نشده.")
         return ConversationHandler.END
     txt = (update.message.text or "").strip()
-    val = None if txt == "-" else txt
+    if txt == "-":
+        val = None
+    else:
+        parts = [x.strip() for x in re.split(r"[\s,;]+", txt) if x.strip()]
+        val = ",".join(parts)
     try:
         with with_mysql_cursor() as cur:
             cur.execute("UPDATE panels SET template_username=%s WHERE id=%s AND telegram_user_id=%s",
@@ -1582,9 +1628,15 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
 
     panels = list_panels_for_agent(owner_id) if not is_admin(owner_id) else list_my_panels_admin(owner_id)
     rows = [p for p in panels if int(p["id"]) in selected_ids]
-    missing = [f"{r['name']}" for r in rows if r.get("panel_type") == "marzneshin" and not r.get("template_username")]
+    missing = [
+        f"{r['name']}"
+        for r in rows
+        if (r.get("panel_type") in ("marzneshin", "sanaei")) and not r.get("template_username")
+    ]
     if missing:
-        await q.edit_message_text("⚠️ این پنل‌ها template ندارند:\n" + "\n".join(f"• {m}" for m in missing))
+        await q.edit_message_text(
+            "⚠️ این پنل‌ها template/inbound ندارند:\n" + "\n".join(f"• {m}" for m in missing)
+        )
         return
 
     per_panel, errs = {}, []
@@ -1599,6 +1651,13 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
                     f"{r['panel_url']} (template '{r['template_username']}'): {e}"
                 )
             per_panel[r["id"]] = {"service_ids": svc or []}
+        elif r.get("panel_type") == "sanaei":
+            inbound_ids = [
+                x.strip()
+                for x in re.split(r"[\s,;]+", str(r.get("template_username") or ""))
+                if x.strip()
+            ]
+            per_panel[r["id"]] = {"inbound_ids": inbound_ids}
         else:
             tmpl = r.get("template_username")
             if not tmpl:
@@ -1636,6 +1695,49 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
                 "note": "created_by_bot",
                 "service_ids": per_panel.get(r["id"], {}).get("service_ids", []),
             }
+        elif r.get("panel_type") == "sanaei":
+            expire_ts = 0 if usage_sec <= 0 else int(datetime.now(timezone.utc).timestamp()) + usage_sec
+            inbound_ids = per_panel.get(r["id"], {}).get("inbound_ids", [])
+            errs_panel = []
+            success_any = False
+            for inb in inbound_ids:
+                client = {
+                    "id": str(uuid.uuid4()),
+                    "email": f"{app_username}__{inb}",
+                    "enable": True,
+                }
+                if limit_bytes > 0:
+                    client["totalGB"] = limit_bytes
+                if expire_ts > 0:
+                    client["expiryTime"] = expire_ts * 1000
+                payload = {
+                    "id": int(inb),
+                    "settings": json.dumps({"clients": [client]}, separators=(",", ":")),
+                }
+                obj, e = api.create_user(r["panel_url"], r["access_token"], payload)
+                if not obj:
+                    obj2, g = api.get_user(
+                        r["panel_url"], r["access_token"], app_username
+                    )
+                    inbound_list = obj2.get("inbound_ids", []) if obj2 else []
+                    if int(inb) not in inbound_list:
+                        errs_panel.append(
+                            f"inbound {inb}: {e or g or 'unknown error'}"
+                        )
+                        continue
+                success_any = True
+            if not success_any:
+                failed.append(f"{r['panel_url']}: " + "; ".join(errs_panel[:3]))
+                continue
+            ok_en, err_en = api.enable_remote_user(r["panel_url"], r["access_token"], app_username)
+            if not ok_en:
+                failed.append(f"{r['panel_url']}: enable failed - {err_en or 'unknown'}")
+            save_link(owner_id, app_username, r["id"], app_username)
+            ok += 1
+            if errs_panel:
+                for er in errs_panel:
+                    failed.append(f"{r['panel_url']}: {er}")
+            continue
         else:
             expire_ts = 0 if usage_sec <= 0 else int(datetime.now(timezone.utc).timestamp()) + usage_sec
             tmpl_info = per_panel.get(r["id"], {})
@@ -1753,6 +1855,88 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
                     if not ok_en:
                         added_errs.append(f"{p['panel_url']}: enable failed - {err_en or 'unknown'}")
 
+                save_link(owner_id, username, int(pid), username)
+                added_ok += 1
+            elif p.get("panel_type") == "sanaei":
+                inbound_ids = [
+                    x.strip()
+                    for x in re.split(r"[\s,;]+", str(tmpl or ""))
+                    if x.strip()
+                ]
+                obj, g = api.get_user(p["panel_url"], p["access_token"], username)
+                existing_inb = set(obj.get("inbound_ids", [])) if obj else set()
+                if not obj:
+                    if not inbound_ids:
+                        added_errs.append(f"{p['panel_url']}: inbound missing & user not found")
+                        continue
+                    errs_local: List[str] = []
+                    success_any = False
+                    for inb in inbound_ids:
+                        client = {
+                            "id": str(uuid.uuid4()),
+                            "email": f"{username}__{inb}",
+                            "enable": True,
+                        }
+                        if limit_bytes_default > 0:
+                            client["totalGB"] = limit_bytes_default
+                        if expire_ts_default > 0:
+                            client["expiryTime"] = expire_ts_default * 1000
+                        payload = {
+                            "id": int(inb),
+                            "settings": json.dumps({"clients": [client]}, separators=(",", ":")),
+                        }
+                        obj2, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
+                        if not obj2:
+                            obj_tmp, g = api.get_user(
+                                p["panel_url"], p["access_token"], username
+                            )
+                            inbound_list = obj_tmp.get("inbound_ids", []) if obj_tmp else []
+                            if int(inb) not in inbound_list:
+                                errs_local.append(
+                                    f"inbound {inb}: {e2 or g or 'unknown error'}",
+                                )
+                                continue
+                        success_any = True
+                    if errs_local:
+                        added_errs.extend(
+                            f"{p['panel_url']}: {er}" for er in errs_local
+                        )
+                    if not success_any:
+                        continue
+                else:
+                    missing = [inb for inb in inbound_ids if int(inb) not in existing_inb]
+                    errs_local: List[str] = []
+                    for inb in missing:
+                        client = {
+                            "id": str(uuid.uuid4()),
+                            "email": f"{username}__{inb}",
+                            "enable": True,
+                        }
+                        if limit_bytes_default > 0:
+                            client["totalGB"] = limit_bytes_default
+                        if expire_ts_default > 0:
+                            client["expiryTime"] = expire_ts_default * 1000
+                        payload = {
+                            "id": int(inb),
+                            "settings": json.dumps({"clients": [client]}, separators=(",", ":")),
+                        }
+                        obj2, e2 = api.create_user(p["panel_url"], p["access_token"], payload)
+                        if not obj2:
+                            obj_tmp, g = api.get_user(
+                                p["panel_url"], p["access_token"], username
+                            )
+                            inbound_list = obj_tmp.get("inbound_ids", []) if obj_tmp else []
+                            if int(inb) not in inbound_list:
+                                errs_local.append(
+                                    f"inbound {inb}: {e2 or g or 'unknown error'}",
+                                )
+                    if errs_local:
+                        added_errs.extend(
+                            f"{p['panel_url']}: {er}" for er in errs_local
+                        )
+                ok_en, err_en = api.enable_remote_user(p["panel_url"], p["access_token"], username)
+                if not ok_en:
+                    added_errs.append(f"{p['panel_url']}: enable failed - {err_en or 'unknown'}")
                 save_link(owner_id, username, int(pid), username)
                 added_ok += 1
             else:

--- a/sanaei.py
+++ b/sanaei.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Helper functions for interacting with MHSanaei/3x-ui panel API.
+
+This implementation provides a minimal subset of the behaviour exposed by
+:mod:`marzneshin` and :mod:`marzban` so that other modules can treat the
+3x-ui panel in a similar fashion.  The 3x-ui panel differs from Marzban and
+Marzneshin in that it does not expose subscription endpoints.  As such,
+configuration links are assembled directly from inbound information
+retrieved via the API and the client's UUID.
+
+The functions favour best-effort behaviour – network failures or unexpected
+payloads are surfaced as error strings instead of raising exceptions.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin, urlparse
+import re
+
+import json
+import requests
+
+ALLOWED_SCHEMES = ("vless://", "vmess://", "trojan://", "ss://")
+
+
+def get_headers(token: str) -> Dict[str, str]:
+    """Return headers (cookie based) for the given session token."""
+    return {"Cookie": token}
+
+
+def fetch_user_services(panel_url: str, token: str, username: str) -> Tuple[Optional[List[int]], Optional[str]]:
+    """3x-ui does not expose service identifiers; return an empty list."""
+    return [], None
+
+
+def create_user(panel_url: str, token: str, payload: Dict) -> Tuple[Optional[Dict], Optional[str]]:
+    """Create a user on the remote panel.
+
+    The 3x-ui API requires the inbound ID and the client object.  Because
+    configuration details vary widely, callers must supply the appropriate
+    payload.  This helper simply forwards the payload to the
+    ``/panel/api/inbounds/addClient`` endpoint.
+    """
+    try:
+        r = requests.post(
+            urljoin(panel_url.rstrip('/') + '/', 'panel/api/inbounds/addClient'),
+            json=payload,
+            headers={**get_headers(token), 'Content-Type': 'application/json'},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return r.json(), None
+        return None, f"{r.status_code} {r.text[:300]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+
+
+def _list_inbounds(panel_url: str, token: str) -> Tuple[Optional[List[Dict]], Optional[str]]:
+    """Return list of inbounds or an error message."""
+    try:
+        r = requests.get(
+            urljoin(panel_url.rstrip('/') + '/', 'panel/api/inbounds/list'),
+            headers={"accept": "application/json", **get_headers(token)},
+            timeout=15,
+        )
+        if r.status_code != 200:
+            return None, f"{r.status_code} {r.text[:200]}"
+        data = r.json() or {}
+        inbounds = data.get('obj') or data.get('inbounds') or []
+        return inbounds, None
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+
+
+def _find_clients(inbounds: List[Dict], username: str) -> List[Tuple[Dict, Dict]]:
+    """Return list of ``(inbound, client)`` pairs for *username*."""
+    matches: List[Tuple[Dict, Dict]] = []
+    for inbound in inbounds:
+        settings = inbound.get('settings') or '{}'
+        try:
+            settings_obj = json.loads(settings) if isinstance(settings, str) else settings
+        except Exception:
+            settings_obj = {}
+        clients = settings_obj.get('clients') or []
+        for cl in clients:
+            email = (
+                cl.get('email')
+                or cl.get('Email')
+                or cl.get('username')
+                or ''
+            )
+            m = re.match(r"^(.*?)(?:__|_)(\d+)$", email)
+            base = m.group(1) if m else email
+            if base == username:
+                matches.append((inbound, cl))
+    return matches
+
+
+def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict], Optional[str]]:
+    """Fetch user details from the panel."""
+    inbounds, err = _list_inbounds(panel_url, token)
+    if err:
+        return None, err
+    matches = _find_clients(inbounds, username)
+    if not matches:
+        return None, 'not found'
+    total_used = 0
+    enabled_all = True
+    inbound_ids: List[int] = []
+    first_inbound, first_client = matches[0]
+    for inbound, client in matches:
+        uuid = client.get('id') or client.get('uuid')
+        inbound_ids.append(int(inbound.get('id'))) if inbound.get('id') is not None else None
+        for st in inbound.get('clientStats', []) or []:
+            if st.get('id') == uuid:
+                up = int(st.get('up', 0) or 0)
+                down = int(st.get('down', 0) or 0)
+                total_used += up + down
+                break
+        enabled_all = enabled_all and bool(client.get('enable', True))
+    obj = {
+        'uuid': first_client.get('id') or first_client.get('uuid'),
+        'enabled': enabled_all,
+        'used_traffic': total_used,
+        'protocol': first_inbound.get('protocol'),
+        'port': first_inbound.get('port'),
+        'listen': first_inbound.get('listen'),
+        'remark': first_inbound.get('remark'),
+        'inbound_ids': inbound_ids,
+    }
+    return obj, None
+
+
+def fetch_links_from_panel(panel_url: str, token: str, username: str) -> Tuple[List[str], Optional[str]]:
+    """Return list of config links for *username*.
+
+    Since the panel does not offer subscription endpoints, configuration
+    links are constructed from inbound information and each client's UUID.
+    """
+    inbounds, err = _list_inbounds(panel_url, token)
+    if err:
+        return [], err
+    matches = _find_clients(inbounds, username)
+    if not matches:
+        return [], 'not found'
+    links: List[str] = []
+    for inbound, client in matches:
+        host = inbound.get('listen') or urlparse(panel_url).hostname or ''
+        port = inbound.get('port')
+        protocol = inbound.get('protocol') or 'vless'
+        uuid = client.get('id') or client.get('uuid') or ''
+        name = client.get('remark') or inbound.get('remark') or username
+        if not (host and port and uuid):
+            continue
+        link = f"{protocol}://{uuid}@{host}:{port}?security=none#{name}"
+        if not any(link.lower().startswith(s) for s in ALLOWED_SCHEMES):
+            link = f"vless://{uuid}@{host}:{port}?security=none#{name}"
+        links.append(link)
+    if not links:
+        return [], 'incomplete config'
+    return links, None
+
+
+def disable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Disable (enable=false) a user on the panel."""
+    try:
+        inbounds, err = _list_inbounds(panel_url, token)
+        if err:
+            return False, err
+        matches = _find_clients(inbounds, username)
+        if not matches:
+            return False, 'not found'
+        ok_any = False
+        errs = []
+        for inbound, client in matches:
+            client['enable'] = False
+            settings = inbound.get('settings') or '{}'
+            settings_obj = json.loads(settings) if isinstance(settings, str) else settings
+            clients = settings_obj.get('clients') or []
+            target_email = (
+                client.get('email') or client.get('Email') or client.get('username')
+            )
+            for idx, cl in enumerate(clients):
+                email = cl.get('email') or cl.get('Email') or cl.get('username')
+                if email == target_email:
+                    clients[idx] = client
+                    break
+            settings_obj['clients'] = clients
+            inbound['settings'] = json.dumps(settings_obj, separators=(',', ':'))
+            r = requests.post(
+                urljoin(panel_url.rstrip('/') + '/', f"panel/api/inbounds/update/{inbound.get('id')}")
+                ,json=inbound,
+                headers={**get_headers(token), 'Content-Type': 'application/json'},
+                timeout=20,
+            )
+            if r.status_code == 200:
+                ok_any = True
+            else:
+                errs.append(f"{inbound.get('id')}: {r.status_code} {r.text[:200]}")
+        return ok_any, (None if ok_any else "; ".join(errs))
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Enable (enable=true) a user on the panel."""
+    try:
+        inbounds, err = _list_inbounds(panel_url, token)
+        if err:
+            return False, err
+        matches = _find_clients(inbounds, username)
+        if not matches:
+            return False, 'not found'
+        ok_any = False
+        errs = []
+        for inbound, client in matches:
+            client['enable'] = True
+            settings = inbound.get('settings') or '{}'
+            settings_obj = json.loads(settings) if isinstance(settings, str) else settings
+            clients = settings_obj.get('clients') or []
+            target_email = (
+                client.get('email') or client.get('Email') or client.get('username')
+            )
+            for idx, cl in enumerate(clients):
+                email = cl.get('email') or cl.get('Email') or cl.get('username')
+                if email == target_email:
+                    clients[idx] = client
+                    break
+            settings_obj['clients'] = clients
+            inbound['settings'] = json.dumps(settings_obj, separators=(',', ':'))
+            r = requests.post(
+                urljoin(panel_url.rstrip('/') + '/', f"panel/api/inbounds/update/{inbound.get('id')}")
+                ,json=inbound,
+                headers={**get_headers(token), 'Content-Type': 'application/json'},
+                timeout=20,
+            )
+            if r.status_code == 200:
+                ok_any = True
+            else:
+                errs.append(f"{inbound.get('id')}: {r.status_code} {r.text[:200]}")
+        return ok_any, (None if ok_any else "; ".join(errs))
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def fetch_subscription_links(sub_url: str) -> List[str]:
+    """Return links from a subscription URL if provided.
+
+    3x-ui does not natively support subscription URLs, but some operators may
+    expose one via custom means.  This function performs a simple GET and
+    returns any plain-text links.
+    """
+    try:
+        r = requests.get(sub_url, headers={"accept": "text/plain"}, timeout=20)
+        if r.status_code != 200:
+            return []
+        return [
+            ln.strip()
+            for ln in (r.text or '').splitlines()
+            if ln.strip() and ln.strip().lower().startswith(ALLOWED_SCHEMES)
+        ]
+    except Exception:  # pragma: no cover - network errors
+        return []
+
+
+def get_admin_token(panel_url: str, username: str, password: str) -> Tuple[Optional[str], Optional[str]]:
+    """Authenticate against the panel and return a session token."""
+    login_url = urljoin(panel_url.rstrip('/') + '/', 'login')
+    try:
+        resp = requests.post(
+            login_url,
+            data={"username": username, "password": password},
+            timeout=15,
+        )
+        if resp.status_code != 200:
+            return None, f"{resp.status_code} {resp.text[:200]}"
+        jar = resp.cookies.get_dict()
+        cookie_name = None
+        cookie_val = None
+        # Prefer known cookie names but fall back to any provided cookie.
+        if '3x-ui' in jar:
+            cookie_name, cookie_val = '3x-ui', jar['3x-ui']
+        elif 'session' in jar:
+            cookie_name, cookie_val = 'session', jar['session']
+        elif jar:
+            cookie_name, cookie_val = next(iter(jar.items()))
+        if not cookie_name or not cookie_val:
+            return None, 'no session cookie'
+        return f"{cookie_name}={cookie_val}", None
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]

--- a/usage_sync.py
+++ b/usage_sync.py
@@ -13,6 +13,7 @@ import mysql.connector
 
 import marzneshin
 import marzban
+import sanaei
 
 logging.basicConfig(
     format="%(asctime)s | %(levelname)s | usage_sync | %(message)s",
@@ -25,6 +26,7 @@ POOL = None
 API_MODULES = {
     "marzneshin": marzneshin,
     "marzban": marzban,
+    "sanaei": sanaei,
 }
 
 


### PR DESCRIPTION
## Summary
- generate unique emails for each specified inbound when adding Sanaei (3x-ui) users so clients are created across all targets
- allow inbound IDs to be split by commas, spaces, or semicolons for more robust multi-inbound handling
- normalize 3x-ui client lookups to strip inbound ID suffixes so usage sync and enable/disable operations find all matching inbounds

## Testing
- `python -m py_compile bot.py usage_sync.py app.py sanaei.py marzban.py marzneshin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b714e267688328ac88c5ab3a6936d3