### PR TITLE
Improve Sanaei panel support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -724,6 +724,11 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await q.edit_message_text("یوزرنیم ادمین جدید را بفرست:") ; return ASK_EDIT_PANEL_USER
     if data == "p_set_sub":
         if not is_admin(uid): return ConversationHandler.END
+        pid = context.user_data.get("edit_panel_id")
+        info = get_panel(uid, pid) if pid else None
+        if info and info.get("panel_type") == "sanaei":
+            await q.edit_message_text("این پنل از لینک سابسکریپشن پشتیبانی نمی‌کند.")
+            return ConversationHandler.END
         await q.edit_message_text("لینک سابسکریپشن پنل را بفرست (برای حذف، '-'):") ; return ASK_PANEL_SUB_URL
     if data == "p_filter_cfgs":
         if not is_admin(uid): return ConversationHandler.END
@@ -731,6 +736,9 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         info = get_panel(uid, pid)
         if not info:
             await q.edit_message_text("پنل پیدا نشد.")
+            return ConversationHandler.END
+        if info.get("panel_type") == "sanaei":
+            await q.edit_message_text("این پنل از فیلتر کانفیگ‌ها پشتیبانی نمی‌کند.")
             return ConversationHandler.END
         if not info.get("sub_url"):
             await q.edit_message_text("اول لینک سابسکریپشن پنل را تنظیم کن (Set/Clear Sub URL).")
@@ -742,6 +750,9 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         info = get_panel(uid, pid)
         if not info:
             await q.edit_message_text("پنل پیدا نشد.")
+            return ConversationHandler.END
+        if info.get("panel_type") == "sanaei":
+            await q.edit_message_text("این پنل از فیلتر کانفیگ‌ها پشتیبانی نمی‌کند.")
             return ConversationHandler.END
         if not info.get("sub_url"):
             await q.edit_message_text("اول لینک سابسکریپشن پنل را تنظیم کن (Set/Clear Sub URL).")
@@ -1175,7 +1186,10 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
         f"🌐 URL: <code>{p['panel_url']}</code>",
         f"👤 Admin: <code>{p['admin_username']}</code>",
         f"🧬 {label}: <b>{p.get('template_username') or '-'}</b>",
-        f"🔗 Sub URL: <code>{p.get('sub_url') or '-'}</code>",
+    ]
+    if not is_sanaei:
+        lines.append(f"🔗 Sub URL: <code>{p.get('sub_url') or '-'}</code>")
+    lines += [
         "",
         "چه کاری انجام بدهم؟",
     ]
@@ -1183,12 +1197,13 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
         [InlineKeyboardButton(f"🧬 Set/Clear {label}", callback_data="p_set_template")],
         [InlineKeyboardButton("🔑 Change Admin Credentials", callback_data="p_change_creds")],
         [InlineKeyboardButton("✏️ Rename Panel", callback_data="p_rename")],
-        [InlineKeyboardButton("🔗 Set/Clear Sub URL", callback_data="p_set_sub")],
-        [InlineKeyboardButton("🧷 فیلتر کانفیگ‌های پنل", callback_data="p_filter_cfgs")],
-        [InlineKeyboardButton("🔢 فیلتر بر اساس شماره", callback_data="p_filter_cfgnums")],
-        [InlineKeyboardButton("🗑️ Remove Panel", callback_data="p_remove")],
-        [InlineKeyboardButton("⬅️ Back", callback_data="manage_panels")],
     ]
+    if not is_sanaei:
+        kb.append([InlineKeyboardButton("🔗 Set/Clear Sub URL", callback_data="p_set_sub")])
+        kb.append([InlineKeyboardButton("🧷 فیلتر کانفیگ‌های پنل", callback_data="p_filter_cfgs")])
+        kb.append([InlineKeyboardButton("🔢 فیلتر بر اساس شماره", callback_data="p_filter_cfgnums")])
+    kb.append([InlineKeyboardButton("🗑️ Remove Panel", callback_data="p_remove")])
+    kb.append([InlineKeyboardButton("⬅️ Back", callback_data="manage_panels")])
     await q.edit_message_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
     return ConversationHandler.END
 
@@ -1335,9 +1350,12 @@ async def got_panel_pass(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 "INSERT INTO panels(telegram_user_id,panel_url,name,panel_type,admin_username,access_token)VALUES(%s,%s,%s,%s,%s,%s)",
                 (update.effective_user.id, panel_url, panel_name, panel_type, panel_user, tok)
             )
-        await update.message.reply_text(
-            f"✅ پنل اضافه شد: {panel_name}\nنکته: از 🛠️ Manage Panels می‌تونی Template و Sub URL را ست کنی."
-        )
+        msg = f"✅ پنل اضافه شد: {panel_name}"
+        if panel_type == "sanaei":
+            msg += "\nنکته: از 🛠️ Manage Panels می‌تونی Inbound ID را ست کنی."
+        else:
+            msg += "\nنکته: از 🛠️ Manage Panels می‌تونی Template و Sub URL را ست کنی."
+        await update.message.reply_text(msg)
     except MySQLError as e:
         await update.message.reply_text(f"❌ خطای DB: {e}")
     except Exception as e:

--- a/sanaei.py
+++ b/sanaei.py
@@ -98,15 +98,23 @@ def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict],
     if not client or not inbound:
         return None, 'not found'
     uuid = client.get('id') or client.get('uuid')
-    enabled = bool(client.get('enable', True))
-    used = 0
-    for st in inbound.get('clientStats', []) or []:
-        if st.get('id') == uuid:
-            up = int(st.get('up', 0) or 0)
-            down = int(st.get('down', 0) or 0)
-            used = up + down
-            break
-    obj = {
+    try:
+        r = requests.get(
+            urljoin(panel_url.rstrip('/') + '/', f"panel/api/inbounds/getClientTraffics/{username}"),
+            headers={"accept": "application/json", **get_headers(token)},
+            timeout=15,
+        )
+        if r.status_code != 200:
+            return None, f"{r.status_code} {r.text[:200]}"
+        data = r.json() or {}
+        obj = data.get('obj') or data
+        up = int(obj.get('up', 0) or 0)
+        down = int(obj.get('down', 0) or 0)
+        enabled = bool(obj.get('enable', True))
+        used = up + down
+    except Exception as e:  # pragma: no cover - network errors
+        return None, str(e)[:200]
+    res = {
         'uuid': uuid,
         'enabled': enabled,
         'used_traffic': used,
@@ -115,7 +123,7 @@ def get_user(panel_url: str, token: str, username: str) -> Tuple[Optional[Dict],
         'listen': inbound.get('listen'),
         'remark': inbound.get('remark'),
     }
-    return obj, None
+    return res, None
 
 
 def fetch_links_from_panel(panel_url: str, token: str, username: str) -> Tuple[List[str], Optional[str]]:


### PR DESCRIPTION
## Summary
- Hide subscription and filter options for Sanaei panels
- Fetch Sanaei traffic stats via getClientTraffics API

## Testing
- `python -m py_compile bot.py sanaei.py usage_sync.py`


------
https://chatgpt.com/codex/tasks/task_b_68b774e2edb0832893b1f5bda4fa2df5