### PR TITLE
Add user deletion with remote panel cleanup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -494,6 +494,64 @@ def renew_user(owner_id: int, username: str, add_days: int):
             params
         )
 
+
+def list_user_links(owner_id: int, local_username: str):
+    ids = expand_owner_ids(owner_id)
+    placeholders = ",".join(["%s"] * len(ids))
+    with with_mysql_cursor() as cur:
+        cur.execute(
+            f"""SELECT lup.panel_id, lup.remote_username,
+                      p.panel_url, p.access_token, p.panel_type
+                 FROM local_user_panel_links lup
+                 JOIN panels p ON p.id = lup.panel_id
+                 WHERE lup.owner_id IN ({placeholders}) AND lup.local_username=%s""",
+            tuple(ids) + (local_username,),
+        )
+        return cur.fetchall()
+
+
+def delete_local_user(owner_id: int, username: str):
+    ids = expand_owner_ids(owner_id)
+    placeholders = ",".join(["%s"] * len(ids))
+    params = tuple(ids) + (username,)
+    with with_mysql_cursor() as cur:
+        cur.execute(
+            f"DELETE FROM local_user_panel_links WHERE owner_id IN ({placeholders}) AND local_username=%s",
+            params,
+        )
+        cur.execute(
+            f"DELETE FROM local_users WHERE owner_id IN ({placeholders}) AND username=%s",
+            params,
+        )
+        cur.execute(
+            f"DELETE FROM app_users WHERE telegram_user_id IN ({placeholders}) AND username=%s",
+            params,
+        )
+
+
+def delete_user(owner_id: int, username: str):
+    rows = list_user_links(owner_id, username)
+    for r in rows:
+        try:
+            api = get_api(r.get("panel_type"))
+            remotes = (
+                r["remote_username"].split(",")
+                if r.get("panel_type") == "sanaei"
+                else [r["remote_username"]]
+            )
+            for rn in remotes:
+                ok, err = api.remove_remote_user(r["panel_url"], r["access_token"], rn)
+                if not ok:
+                    log.warning(
+                        "remote delete failed on %s@%s: %s",
+                        rn,
+                        r["panel_url"],
+                        err or "unknown",
+                    )
+        except Exception as e:
+            log.warning("remote delete exception: %s", e)
+    delete_local_user(owner_id, username)
+
 # panels extra
 def set_panel_sub_url(owner_id: int, panel_id: int, sub_url: str | None):
     ids = expand_owner_ids(owner_id)
@@ -980,6 +1038,27 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return ConversationHandler.END
         return await show_panel_select(q, context, uid, mode="edit", username=uname)
 
+    if data == "act_del_user":
+        uname = context.user_data.get("manage_username")
+        if not uname:
+            await q.edit_message_text("یوزر انتخاب نشده.")
+            return ConversationHandler.END
+        kb = InlineKeyboardMarkup([
+            [InlineKeyboardButton("🗑️ بله، حذف کن", callback_data="act_del_user_yes")],
+            [InlineKeyboardButton("⬅️ انصراف", callback_data=f"user_sel:{uname}")],
+        ])
+        await q.edit_message_text(f"کاربر {uname} حذف شود؟", reply_markup=kb)
+        return ConversationHandler.END
+
+    if data == "act_del_user_yes":
+        uname = context.user_data.get("manage_username")
+        if not uname:
+            await q.edit_message_text("یوزر انتخاب نشده.")
+            return ConversationHandler.END
+        delete_user(uid, uname)
+        await q.edit_message_text("✅ کاربر حذف شد.")
+        return ConversationHandler.END
+
     # ----- agent mgmt (admin) -----
     if data == "manage_agents":
         if not is_admin(uid):
@@ -1403,6 +1482,7 @@ async def show_user_card(q, owner_id: int, uname: str, notice: str = None):
         [InlineKeyboardButton("🧹 Reset Used", callback_data="act_reset_used")],
         [InlineKeyboardButton("🔁 Renew (add days)", callback_data="act_renew")],
         [InlineKeyboardButton("🧩 Panels", callback_data="act_user_panels")],
+        [InlineKeyboardButton("🗑️ Delete User", callback_data="act_del_user")],
         [InlineKeyboardButton("⬅️ Back", callback_data="list_users:0")],
     ]
     await q.edit_message_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")

--- a/marzban.py
+++ b/marzban.py
@@ -144,6 +144,21 @@ def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Delete a user on the panel."""
+    try:
+        r = requests.delete(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/user/{username}"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL.
 

--- a/marzneshin.py
+++ b/marzneshin.py
@@ -117,6 +117,21 @@ def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Delete a user on the panel."""
+    try:
+        r = requests.delete(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/users/{username}"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL."""
     try:

--- a/sanaei.py
+++ b/sanaei.py
@@ -220,6 +220,28 @@ def enable_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Delete a user (client) from the panel."""
+    try:
+        inbounds, err = _list_inbounds(panel_url, token)
+        if err:
+            return False, err
+        inbound, client = _find_client(inbounds, username)
+        if not client or not inbound:
+            return False, 'not found'
+        uuid = client.get('id') or client.get('uuid')
+        url = urljoin(
+            panel_url.rstrip('/') + '/',
+            f"panel/api/inbounds/{inbound.get('id')}/delClient/{uuid}",
+        )
+        r = requests.post(url, headers=get_headers(token), timeout=20)
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL if provided.
 


### PR DESCRIPTION
## Summary
- Add Delete User action in management panel
- Implement per-panel API helpers to remove users
- Remove local and remote data when deleting a user

## Testing
- `python -m py_compile marzneshin.py marzban.py sanaei.py bot.py`


------
https://chatgpt.com/codex/tasks/task_b_68b8a20c05908328a81009a6a34de7c7