### PR TITLE
feat: add basic service grouping

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -46,6 +46,7 @@ from telegram.ext import (
 )
 
 import usage_sync
+import services
 
 # ---------- logging ----------
 logging.basicConfig(
@@ -283,6 +284,34 @@ def ensure_schema():
                 panel_id BIGINT NOT NULL,
                 UNIQUE KEY uq_agent_panel(agent_tg_id, panel_id),
                 FOREIGN KEY (panel_id) REFERENCES panels(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+
+        # services
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS services(
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                owner_id BIGINT NOT NULL,
+                name VARCHAR(128) NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_owner_name(owner_id, name)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS service_panels(
+                service_id BIGINT NOT NULL,
+                panel_id BIGINT NOT NULL,
+                UNIQUE KEY uq_service_panel(service_id, panel_id),
+                FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+                FOREIGN KEY (panel_id) REFERENCES panels(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS service_users(
+                service_id BIGINT NOT NULL,
+                local_username VARCHAR(64) NOT NULL,
+                UNIQUE KEY uq_service_user(service_id, local_username),
+                FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
         """)
 
@@ -534,6 +563,11 @@ def list_user_links(owner_id: int, local_username: str):
         return cur.fetchall()
 
 
+def list_mapped_links(owner_id: int, local_username: str):
+    """Compatibility wrapper returning panel mappings for a user."""
+    return list_user_links(owner_id, local_username)
+
+
 def delete_local_user(owner_id: int, username: str):
     ids = expand_owner_ids(owner_id)
     placeholders = ",".join(["%s"] * len(ids))
@@ -675,6 +709,19 @@ def list_panel_links(panel_id: int):
             WHERE lup.panel_id=%s
         """, (int(panel_id),))
         return cur.fetchall()
+
+
+def disable_remote(panel_type, panel_url, token, remote_username):
+    """Disable a remote user across different panel types."""
+    api = get_api(panel_type)
+    remotes = remote_username.split(",") if panel_type == "sanaei" else [remote_username]
+    all_ok, last_msg = True, None
+    for rn in remotes:
+        ok, msg = api.disable_remote_user(panel_url, token, rn)
+        if not ok:
+            all_ok = False
+            last_msg = msg
+    return (200 if all_ok else None), last_msg
 
 def delete_panel_and_cleanup(owner_id: int, panel_id: int):
     # 1) disable all mapped remote users on that panel
@@ -2296,6 +2343,19 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
         note += "\n⚠️ خطاها:\n" + "\n".join(f"• {e}" for e in added_errs[:10])
     await show_user_card(q, owner_id, username, notice=note)
 
+
+# ---------- services ----------
+async def add_service_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Create a new service (admin only)."""
+    if not is_admin(update.effective_user.id):
+        return
+    name = " ".join(context.args or [])
+    if not name:
+        await update.message.reply_text("Usage: /addservice <name>")
+        return
+    sid = services.create_service(name, canonical_owner_id(update.effective_user.id))
+    await update.message.reply_text(f"Service created with id {sid}")
+
 # ---------- wiring ----------
 def build_app():
     load_dotenv()
@@ -2304,6 +2364,8 @@ def build_app():
         raise RuntimeError("BOT_TOKEN missing in .env")
     init_mysql_pool()
     ensure_schema()
+    services.set_pool(MYSQL_POOL)
+    services.set_helpers(disable_remote, list_mapped_links)
     app = Application.builder().token(tok).build()
 
     conv = ConversationHandler(
@@ -2350,6 +2412,7 @@ def build_app():
         allow_reentry=True,
     )
     app.add_handler(conv)
+    app.add_handler(CommandHandler("addservice", add_service_cmd))
     return app
 
 if __name__ == "__main__":

--- a/services.py
+++ b/services.py
@@ -1,0 +1,131 @@
+"""Service management utilities.
+
+This module manages a higher level grouping called *service* which bundles
+multiple panels together. Agents receive access to services instead of direct
+panel access. Functions here operate purely on the database layer; the Telegram
+bot wires them to user interactions.
+"""
+
+from __future__ import annotations
+
+from typing import List, Callable
+from mysql.connector import Error
+
+MYSQL_POOL = None
+_disable_remote: Callable | None = None
+_list_mapped_links: Callable | None = None
+
+
+def set_pool(pool):
+    """Assign MySQL connection pool used by the bot."""
+    global MYSQL_POOL
+    MYSQL_POOL = pool
+
+
+def set_helpers(disable_remote_fn: Callable, list_links_fn: Callable) -> None:
+    """Inject helper callbacks from the bot module."""
+    global _disable_remote, _list_mapped_links
+    _disable_remote = disable_remote_fn
+    _list_mapped_links = list_links_fn
+
+
+def _ctx():
+    class _Ctx:
+        def __enter__(self):
+            self.conn = MYSQL_POOL.get_connection()
+            self.cur = self.conn.cursor(dictionary=True)
+            return self.cur
+        def __exit__(self, exc_type, exc, tb):
+            if exc_type is None:
+                self.conn.commit()
+            else:
+                self.conn.rollback()
+            self.cur.close()
+            self.conn.close()
+    return _Ctx()
+
+
+def create_service(name: str, owner_id: int) -> int:
+    """Create a service and return its id."""
+    with _ctx() as cur:
+        cur.execute(
+            "INSERT INTO services (name, owner_id) VALUES (%s, %s)",
+            (name, owner_id),
+        )
+        return int(cur.lastrowid)
+
+
+def add_panel_to_service(service_id: int, panel_id: int) -> None:
+    with _ctx() as cur:
+        cur.execute(
+            "INSERT IGNORE INTO service_panels (service_id, panel_id) VALUES (%s, %s)",
+            (service_id, panel_id),
+        )
+    propagate_service_users_to_panel(service_id, panel_id)
+
+
+def remove_panel_from_service(service_id: int, panel_id: int) -> None:
+    with _ctx() as cur:
+        cur.execute(
+            "DELETE FROM service_panels WHERE service_id=%s AND panel_id=%s",
+            (service_id, panel_id),
+        )
+    disable_users_on_panel(service_id, panel_id)
+
+
+def service_usernames(service_id: int) -> List[str]:
+    with _ctx() as cur:
+        cur.execute(
+            "SELECT local_username FROM service_users WHERE service_id=%s",
+            (service_id,),
+        )
+        return [r["local_username"] for r in cur.fetchall()]
+
+
+def assign_user_to_service(service_id: int, local_username: str) -> None:
+    with _ctx() as cur:
+        cur.execute(
+            "INSERT IGNORE INTO service_users (service_id, local_username) VALUES (%s, %s)",
+            (service_id, local_username),
+        )
+
+
+def _owner_id(service_id: int) -> int | None:
+    with _ctx() as cur:
+        cur.execute("SELECT owner_id FROM services WHERE id=%s LIMIT 1", (service_id,))
+        row = cur.fetchone()
+    return int(row["owner_id"]) if row else None
+
+
+def propagate_service_users_to_panel(service_id: int, panel_id: int) -> None:
+    owner_id = _owner_id(service_id)
+    if owner_id is None or _list_mapped_links is None:
+        return
+    for username in service_usernames(service_id):
+        links = _list_mapped_links(owner_id, username)
+        if any(l["panel_id"] == panel_id for l in links):
+            continue
+        with _ctx() as cur:
+            cur.execute(
+                "INSERT INTO local_user_panel_links (owner_id, panel_id, local_username, remote_username)"
+                " VALUES (%s, %s, %s, %s)",
+                (owner_id, panel_id, username, username),
+            )
+
+
+def disable_users_on_panel(service_id: int, panel_id: int) -> None:
+    owner_id = _owner_id(service_id)
+    if owner_id is None or _disable_remote is None or _list_mapped_links is None:
+        return
+    for username in service_usernames(service_id):
+        links = [l for l in _list_mapped_links(owner_id, username) if l["panel_id"] == panel_id]
+        for l in links:
+            try:
+                _disable_remote(l["panel_type"], l["panel_url"], l["access_token"], l["remote_username"])
+            except Error:
+                pass
+            with _ctx() as cur:
+                cur.execute(
+                    "DELETE FROM local_user_panel_links WHERE owner_id=%s AND panel_id=%s AND local_username=%s",
+                    (owner_id, panel_id, username),
+                )


### PR DESCRIPTION
## Summary
- add service management module for grouping panels
- extend schema and command handler to create services
- wire helper callbacks for service user propagation

## Testing
- `python -m py_compile services.py bot.py`
- `python bot.py` *(fails: BOT_TOKEN missing in .env)*

------
https://chatgpt.com/codex/tasks/task_b_68bc2d9990fc832893a43b4114ad4d28