### PR TITLE
Add service management layer with panel assignments

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8,10 +8,11 @@ Admin:
 - Remove panel (disables all mapped users on that panel first)
 - Manage agents: add/edit (name), set agent quota (bytes), renew expiry by **days**, activate/deactivate
 - Assign panels to agents (checkbox)
+- Manage services (group panels under a service)
 Agent:
-- New local user (with panel multi-select limited to assigned panels)
+- New local user (assign a service)
 - Search/list users
-- Edit user (limit/reset/renew + panel selection limited to assigned)
+- Edit user (limit/reset/renew + change service)
 
 Shared:
 - Unified subscription link per user
@@ -124,7 +125,7 @@ def canonical_owner_id(owner_id: int) -> int:
     ASK_SEARCH_USER, ASK_PANEL_TEMPLATE,
     ASK_EDIT_LIMIT, ASK_RENEW_DAYS,
     ASK_EDIT_PANEL_NAME, ASK_EDIT_PANEL_USER, ASK_EDIT_PANEL_PASS,
-    ASK_SELECT_PANELS,
+    ASK_SELECT_SERVICE,
     ASK_PANEL_SUB_URL,
 
     # agent mgmt
@@ -133,7 +134,10 @@ def canonical_owner_id(owner_id: int) -> int:
     ASK_AGENT_MAX_USERS, ASK_AGENT_MAX_USER_GB,
     ASK_ASSIGN_AGENT_PANELS,
     ASK_PANEL_REMOVE_CONFIRM,
-) = range(25)
+
+    # service mgmt
+    ASK_SERVICE_NAME, ASK_EDIT_SERVICE_NAME, ASK_ASSIGN_SERVICE_PANELS,
+) = range(28)
 
 # ---------- MySQL ----------
 MYSQL_POOL = None
@@ -286,6 +290,33 @@ def ensure_schema():
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
         """)
 
+        # services
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS services(
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(128) NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS service_panels(
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                service_id BIGINT NOT NULL,
+                panel_id BIGINT NOT NULL,
+                UNIQUE KEY uq_service_panel(service_id, panel_id),
+                FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE,
+                FOREIGN KEY (panel_id) REFERENCES panels(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        """)
+        try:
+            cur.execute("ALTER TABLE agents ADD COLUMN service_id BIGINT NULL")
+        except MySQLError:
+            pass
+        try:
+            cur.execute("ALTER TABLE local_users ADD COLUMN service_id BIGINT NULL")
+        except MySQLError:
+            pass
+
 # ---------- helpers ----------
 UNIT = 1024
 
@@ -363,6 +394,70 @@ def list_panels_for_agent(agent_tg_id: int):
             ORDER BY p.created_at DESC
         """, (agent_tg_id,))
         return cur.fetchall()
+
+# ----- service helpers -----
+def create_service(name: str) -> int:
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute("INSERT INTO services(name) VALUES(%s)", (name,))
+        return cur.lastrowid
+
+def list_services():
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT * FROM services ORDER BY created_at DESC")
+        return cur.fetchall()
+
+def get_service(sid: int):
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT * FROM services WHERE id=%s", (sid,))
+        return cur.fetchone()
+
+def list_service_panel_ids(service_id: int) -> set[int]:
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute("SELECT panel_id FROM service_panels WHERE service_id=%s", (service_id,))
+        return {int(r[0]) for r in cur.fetchall()}
+
+def set_service_panels(service_id: int, panel_ids: set[int]):
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute("DELETE FROM service_panels WHERE service_id=%s", (service_id,))
+        if panel_ids:
+            cur.executemany(
+                "INSERT INTO service_panels(service_id,panel_id) VALUES(%s,%s)",
+                [(service_id, int(pid)) for pid in panel_ids],
+            )
+
+def list_agents_by_service(service_id: int):
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT telegram_user_id FROM agents WHERE service_id=%s", (service_id,))
+        return [int(r["telegram_user_id"]) for r in cur.fetchall()]
+
+def list_local_users_by_service(service_id: int):
+    with with_mysql_cursor() as cur:
+        cur.execute("SELECT owner_id, username FROM local_users WHERE service_id=%s", (service_id,))
+        return cur.fetchall()
+
+def set_agent_service(agent_tg_id: int, service_id: int | None):
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute("UPDATE agents SET service_id=%s WHERE telegram_user_id=%s", (service_id, agent_tg_id))
+    # sync agent panels to service
+    pids = list_service_panel_ids(service_id) if service_id else set()
+    set_agent_panels(agent_tg_id, pids)
+
+def set_local_user_service(owner_id: int, username: str, service_id: int | None):
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute(
+            "UPDATE local_users SET service_id=%s WHERE owner_id=%s AND username=%s",
+            (service_id, owner_id, username),
+        )
+    pids = list_service_panel_ids(service_id) if service_id else set()
+    sync_user_panels(owner_id, username, pids)
+
+def propagate_service_panels(service_id: int):
+    """After service panels change, update agents/users accordingly."""
+    pids = list_service_panel_ids(service_id)
+    for ag_id in list_agents_by_service(service_id):
+        set_agent_panels(ag_id, pids)
+    for row in list_local_users_by_service(service_id):
+        sync_user_panels(row["owner_id"], row["username"], pids)
 
 def upsert_app_user(tg_id: int, u: str) -> str:
     owner_ids = expand_owner_ids(tg_id)
@@ -494,6 +589,19 @@ def update_limit(owner_id: int, username: str, new_limit_bytes: int):
             f"UPDATE local_users SET plan_limit_bytes=%s WHERE owner_id IN ({placeholders}) AND username=%s",
             params
         )
+    for row in list_user_links(owner_id, username):
+        api = get_api(row.get("panel_type"))
+        remotes = (
+            row["remote_username"].split(",")
+            if row.get("panel_type") == "sanaei"
+            else [row["remote_username"]]
+        )
+        for rn in remotes:
+            ok, err = api.update_remote_user(
+                row["panel_url"], row["access_token"], rn, data_limit=new_limit_bytes
+            )
+            if not ok:
+                log.warning("remote limit update failed on %s: %s", row["panel_url"], err)
 
 def reset_used(owner_id: int, username: str):
     ids = expand_owner_ids(owner_id)
@@ -504,6 +612,19 @@ def reset_used(owner_id: int, username: str):
             f"UPDATE local_users SET used_bytes=0 WHERE owner_id IN ({placeholders}) AND username=%s",
             params
         )
+    for row in list_user_links(owner_id, username):
+        api = get_api(row.get("panel_type"))
+        remotes = (
+            row["remote_username"].split(",")
+            if row.get("panel_type") == "sanaei"
+            else [row["remote_username"]]
+        )
+        for rn in remotes:
+            ok, err = api.reset_remote_user_usage(
+                row["panel_url"], row["access_token"], rn
+            )
+            if not ok:
+                log.warning("remote reset failed on %s: %s", row["panel_url"], err)
 
 def renew_user(owner_id: int, username: str, add_days: int):
     ids = expand_owner_ids(owner_id)
@@ -517,6 +638,30 @@ def renew_user(owner_id: int, username: str, add_days: int):
                WHERE owner_id IN ({placeholders}) AND username=%s""",
             params
         )
+    with with_mysql_cursor() as cur:
+        cur.execute(
+            f"SELECT expire_at FROM local_users WHERE owner_id IN ({placeholders}) AND username=%s",
+            tuple(ids) + (username,),
+        )
+        row = cur.fetchone()
+    expire_ts = 0
+    if row and row.get("expire_at"):
+        expire_dt = row["expire_at"]
+        if isinstance(expire_dt, datetime):
+            expire_ts = int(expire_dt.replace(tzinfo=timezone.utc).timestamp())
+    for r in list_user_links(owner_id, username):
+        api = get_api(r.get("panel_type"))
+        remotes = (
+            r["remote_username"].split(",")
+            if r.get("panel_type") == "sanaei"
+            else [r["remote_username"]]
+        )
+        for rn in remotes:
+            ok, err = api.update_remote_user(
+                r["panel_url"], r["access_token"], rn, expire=expire_ts
+            )
+            if not ok:
+                log.warning("remote renew failed on %s: %s", r["panel_url"], err)
 
 
 def list_user_links(owner_id: int, local_username: str):
@@ -819,78 +964,71 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     else:
         await update.callback_query.edit_message_text(text, reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
 
-def _panel_select_kb(panels, selected: set, mode: str):
+def _panel_select_kb(panels, selected: set):
     rows = []
     for p in panels:
         pid = int(p["id"])
         mark = "✅" if pid in selected else "⬜"
         title = f"{mark} {p['name']} ({p.get('panel_type', 'marzneshin')})"
-        if mode == "assign":
-            cb = f"ap:toggle:{pid}"
-        else:
-            cb = f"selpanel:toggle:{pid}"
-        rows.append([InlineKeyboardButton(title[:64], callback_data=cb)])
-
-    if mode == "assign":
-        prefix = "ap"
-        apply_cb = "ap:apply"
-        cancel_cb = "ap:cancel"
-    else:
-        prefix = "selpanel"
-        apply_cb = f"selpanel:apply:{mode}"
-        cancel_cb = "selpanel:cancel"
+        rows.append([InlineKeyboardButton(title[:64], callback_data=f"ap:toggle:{pid}")])
 
     rows.append([
-        InlineKeyboardButton("☑️ All", callback_data=f"{prefix}:all"),
-        InlineKeyboardButton("🔲 None", callback_data=f"{prefix}:none"),
+        InlineKeyboardButton("☑️ All", callback_data="ap:all"),
+        InlineKeyboardButton("🔲 None", callback_data="ap:none"),
     ])
     rows.append([
-        InlineKeyboardButton("✅ Apply", callback_data=apply_cb),
-        InlineKeyboardButton("❌ Cancel", callback_data=cancel_cb),
+        InlineKeyboardButton("✅ Apply", callback_data="ap:apply"),
+        InlineKeyboardButton("❌ Cancel", callback_data="ap:cancel"),
     ])
     return InlineKeyboardMarkup(rows)
 
-async def show_panel_select(update_or_q, context, owner_id: int, mode: str, username: str = None):
-    panels = list_panels_for_agent(owner_id) if not is_admin(owner_id) else list_my_panels_admin(owner_id)
+def _service_panel_select_kb(panels, selected: set):
+    rows = []
+    for p in panels:
+        pid = int(p["id"])
+        mark = "✅" if pid in selected else "⬜"
+        title = f"{mark} {p['name']} ({p.get('panel_type', 'marzneshin')})"
+        rows.append([InlineKeyboardButton(title[:64], callback_data=f"sp:toggle:{pid}")])
+    rows.append([
+        InlineKeyboardButton("☑️ All", callback_data="sp:all"),
+        InlineKeyboardButton("🔲 None", callback_data="sp:none"),
+    ])
+    rows.append([
+        InlineKeyboardButton("✅ Apply", callback_data="sp:apply"),
+        InlineKeyboardButton("❌ Cancel", callback_data="sp:cancel"),
+    ])
+    return InlineKeyboardMarkup(rows)
+
+async def show_service_panel_select(q, context, service_id: int):
+    uid = q.from_user.id
+    panels = list_my_panels_admin(uid)
     if not panels:
-        msg = "❌ هیچ پنلی ثبت نشده."
+        await q.edit_message_text("هیچ پنلی ثبت نشده.")
+        return ConversationHandler.END
+    selected = list_service_panel_ids(service_id)
+    context.user_data["sp_panels"] = panels
+    context.user_data["sp_selected"] = set(selected)
+    context.user_data["service_id"] = service_id
+    kb = _service_panel_select_kb(panels, set(selected))
+    await q.edit_message_text("پنل‌های سرویس را انتخاب کن:", reply_markup=kb)
+    return ASK_ASSIGN_SERVICE_PANELS
+
+async def show_service_select(update_or_q, context, owner_id: int):
+    services = list_services()
+    if not services:
+        msg = "❌ هیچ سرویسی ثبت نشده. از Admin Panel ایجاد کن."
         if hasattr(update_or_q, "edit_message_text"):
             await update_or_q.edit_message_text(msg)
         else:
             await update_or_q.message.reply_text(msg)
         return ConversationHandler.END
-
-    if mode == "create":
-        panels = [
-            p for p in panels
-            if not ((p.get("panel_type") in ("marzneshin", "sanaei")) and not p.get("template_username"))
-        ]
-        if not panels:
-            txt = "⚠️ هیچ پنلی template/inbound ندارد. از 🛠️ Manage Panels تنظیم کن."
-            if hasattr(update_or_q, "edit_message_text"):
-                await update_or_q.edit_message_text(txt)
-            else:
-                await update_or_q.message.reply_text(txt)
-            return ConversationHandler.END
-        selected = {int(p["id"]) for p in panels}
-    else:
-        linked = list_linked_panel_ids(owner_id, username)
-        selected = set(linked)
-
-    context.user_data["panel_select_mode"] = mode
-    context.user_data["panel_select_username"] = username
-    context.user_data["panel_select_list"] = panels
-    context.user_data["panel_selected"] = selected
-
-    text = ("پنل‌های فعال برای ساخت یوزر جدید را انتخاب کن:"
-            if mode == "create"
-            else f"پنل‌های فعال برای <b>{username}</b> را انتخاب/غیرفعال کن:")
-    kb = _panel_select_kb(panels, selected, mode)
+    kb = [[InlineKeyboardButton(r['name'], callback_data=f"selservice:{r['id']}")] for r in services]
+    kb.append([InlineKeyboardButton("❌ Cancel", callback_data="selservice:cancel")])
     if hasattr(update_or_q, "edit_message_text"):
-        await update_or_q.edit_message_text(text, reply_markup=kb, parse_mode="HTML")
+        await update_or_q.edit_message_text("سرویس را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
     else:
-        await update_or_q.message.reply_text(text, reply_markup=kb, parse_mode="HTML")
-    return ASK_SELECT_PANELS
+        await update_or_q.message.reply_text("سرویس را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
+    return ASK_SELECT_SERVICE
 
 # ---------- buttons ----------
 async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -906,6 +1044,8 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         kb = [
             [InlineKeyboardButton("➕ Add Panel", callback_data="add_panel")],
             [InlineKeyboardButton("🛠️ Manage Panels", callback_data="manage_panels")],
+            [InlineKeyboardButton("🆕 Add Service", callback_data="add_service")],
+            [InlineKeyboardButton("🧰 Manage Services", callback_data="manage_services")],
             [InlineKeyboardButton("👑 Manage Agents", callback_data="manage_agents")],
             [InlineKeyboardButton("⬅️ Back", callback_data="back_home")],
         ]
@@ -920,6 +1060,13 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await q.edit_message_text("🧾 اسم پنل را بفرست:")
         return ASK_PANEL_NAME
 
+    if data == "add_service":
+        if not is_admin(uid):
+            await q.edit_message_text("فقط ادمین می‌تواند سرویس اضافه کند.")
+            return ConversationHandler.END
+        await q.edit_message_text("🧾 اسم سرویس را بفرست:")
+        return ASK_SERVICE_NAME
+
     if data == "manage_panels":
         if not is_admin(uid):
             await q.edit_message_text("دسترسی ندارید.")
@@ -932,6 +1079,49 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
                                     callback_data=f"panel_sel:{r['id']}")] for r in rows]
         kb.append([InlineKeyboardButton("⬅️ Back", callback_data="back_home")])
         await q.edit_message_text("یک پنل را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
+        return ConversationHandler.END
+
+    if data == "manage_services":
+        if not is_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        rows = list_services()
+        if not rows:
+            await q.edit_message_text("هیچ سرویسی ثبت نشده. ابتدا ➕ Add Service.")
+            return ConversationHandler.END
+        kb = [[InlineKeyboardButton(f"{r['name']}"[:64],
+                                    callback_data=f"service_sel:{r['id']}")] for r in rows]
+        kb.append([InlineKeyboardButton("⬅️ Back", callback_data="back_home")])
+        await q.edit_message_text("یک سرویس را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
+        return ConversationHandler.END
+
+    if data.startswith("service_sel:"):
+        if not is_admin(uid):
+            await q.edit_message_text("دسترسی ندارید.")
+            return ConversationHandler.END
+        sid = int(data.split(":", 1)[1])
+        context.user_data["service_id"] = sid
+        return await show_service_card(q, context, sid)
+
+    if data == "service_assign_panels":
+        if not is_admin(uid):
+            return ConversationHandler.END
+        sid = context.user_data.get("service_id")
+        return await show_service_panel_select(q, context, sid)
+
+    if data == "service_rename":
+        if not is_admin(uid):
+            return ConversationHandler.END
+        await q.edit_message_text("اسم جدید سرویس را بفرست:")
+        return ASK_EDIT_SERVICE_NAME
+
+    if data == "service_delete":
+        if not is_admin(uid):
+            return ConversationHandler.END
+        sid = context.user_data.get("service_id")
+        with with_mysql_cursor(dict_=False) as cur:
+            cur.execute("DELETE FROM services WHERE id=%s", (sid,))
+        await q.edit_message_text("سرویس حذف شد.")
         return ConversationHandler.END
 
     if data.startswith("panel_sel:"):
@@ -1055,12 +1245,26 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if data == "act_renew":
         await q.edit_message_text("چند روز اضافه شود؟ (مثلا 30)") ; return ASK_RENEW_DAYS
 
-    if data == "act_user_panels":
+    if data == "act_assign_service":
         uname = context.user_data.get("manage_username")
-        if not uname:
-            await q.edit_message_text("یوزر انتخاب نشده.")
+        rows = list_services()
+        if not rows:
+            await q.edit_message_text("هیچ سرویسی ثبت نشده.")
             return ConversationHandler.END
-        return await show_panel_select(q, context, uid, mode="edit", username=uname)
+        kb = [[InlineKeyboardButton(r['name'], callback_data=f"user_service:{r['id']}")] for r in rows]
+        kb.append([InlineKeyboardButton("⬅️ Back", callback_data="user_sel_back")])
+        await q.edit_message_text("یک سرویس را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
+        return ConversationHandler.END
+
+    if data.startswith("user_service:"):
+        uname = context.user_data.get("manage_username")
+        sid = int(data.split(":",1)[1])
+        set_local_user_service(uid, uname, sid)
+        return await show_user_card(q, uid, uname, notice="✅ سرویس کاربر ذخیره شد.")
+
+    if data == "user_sel_back":
+        uname = context.user_data.get("manage_username")
+        return await show_user_card(q, uid, uname)
 
     if data == "act_del_user":
         uname = context.user_data.get("manage_username")
@@ -1138,6 +1342,29 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         a = context.user_data.get("agent_tg_id")
         return await show_assign_panels(q, context, a)
 
+    if data == "agent_assign_service":
+        if not is_admin(uid): return ConversationHandler.END
+        a = context.user_data.get("agent_tg_id")
+        rows = list_services()
+        if not rows:
+            await q.edit_message_text("هیچ سرویسی ثبت نشده.")
+            return ConversationHandler.END
+        kb = [[InlineKeyboardButton(r['name'], callback_data=f"agent_service:{r['id']}")] for r in rows]
+        kb.append([InlineKeyboardButton("⬅️ Back", callback_data="agent_sel_back")])
+        await q.edit_message_text("یک سرویس را انتخاب کن:", reply_markup=InlineKeyboardMarkup(kb))
+        return ConversationHandler.END
+
+    if data.startswith("agent_service:"):
+        if not is_admin(uid): return ConversationHandler.END
+        a = context.user_data.get("agent_tg_id")
+        sid = int(data.split(":",1)[1])
+        set_agent_service(a, sid)
+        return await show_agent_card(q, context, a, notice="✅ سرویس نماینده ذخیره شد.")
+
+    if data == "agent_sel_back":
+        a = context.user_data.get("agent_tg_id")
+        return await show_agent_card(q, context, a)
+
     if data.startswith("ap:"):
         if not is_admin(uid): return ConversationHandler.END
         a = context.user_data.get("agent_tg_id")
@@ -1158,55 +1385,54 @@ async def on_button(update: Update, context: ContextTypes.DEFAULT_TYPE):
         elif cmd == "cancel":
             return await show_agent_card(q, context, a)
         context.user_data["ap_selected"] = selected
-        kb = _panel_select_kb(panels, selected, mode="assign")
+        kb = _panel_select_kb(panels, selected)
         await q.edit_message_text("پنل‌های این نماینده:", reply_markup=kb)
+        return ConversationHandler.END
+
+    if data.startswith("sp:"):
+        if not is_admin(uid): return ConversationHandler.END
+        sid = context.user_data.get("service_id")
+        cmd = data.split(":",1)[1]
+        panels = context.user_data.get("sp_panels") or []
+        selected = context.user_data.get("sp_selected") or set()
+        if cmd == "all":
+            selected = {int(p["id"]) for p in panels}
+        elif cmd == "none":
+            selected = set()
+        elif cmd.startswith("toggle:"):
+            pid = int(cmd.split(":",1)[1])
+            if pid in selected: selected.remove(pid)
+            else: selected.add(pid)
+        elif cmd == "apply":
+            set_service_panels(sid, selected)
+            propagate_service_panels(sid)
+            return await show_service_card(q, context, sid, notice="✅ پنل‌های سرویس ذخیره شد.")
+        elif cmd == "cancel":
+            return await show_service_card(q, context, sid)
+        context.user_data["sp_selected"] = selected
+        kb = _service_panel_select_kb(panels, selected)
+        await q.edit_message_text("پنل‌های سرویس:", reply_markup=kb)
         return ConversationHandler.END
 
     if data == "back_home":
         await start(update, context)
         return ConversationHandler.END
 
-    # ---- panel multi-select handlers ----
-    if data.startswith("selpanel:"):
-        mode = context.user_data.get("panel_select_mode")
-        panels = context.user_data.get("panel_select_list") or []
-        selected = context.user_data.get("panel_selected") or set()
-
-        if data == "selpanel:all":
-            selected = {int(p["id"]) for p in panels}
-        elif data == "selpanel:none":
-            selected = set()
-        elif data.startswith("selpanel:toggle:"):
-            pid = int(data.split(":", 2)[2])
-            if pid in selected: selected.remove(pid)
-            else: selected.add(pid)
-        elif data.startswith("selpanel:apply:"):
-            which = data.split(":", 2)[2]
-            if which != mode:
-                pass
-            if mode == "create":
-                await q.edit_message_text("⏳ در حال ساخت روی پنل‌های انتخابی ...")
-                await finalize_create_on_selected(q, context, uid, selected)
-            else:
-                uname = context.user_data.get("panel_select_username")
-                await q.edit_message_text("⏳ در حال اعمال تغییرات پنل‌های کاربر ...")
-                await apply_edit_user_panels(q, uid, uname, selected)
+    # ---- service selection during user creation ----
+    if data.startswith("selservice:"):
+        cmd = data.split(":",1)[1]
+        if cmd == "cancel":
+            await q.edit_message_text("لغو شد.")
             return ConversationHandler.END
-        elif data == "selpanel:cancel":
-            if mode == "create":
-                await q.edit_message_text("لغو شد.")
-                return ConversationHandler.END
-            else:
-                uname = context.user_data.get("panel_select_username")
-                return await show_user_card(q, uid, uname)
-
-        context.user_data["panel_selected"] = selected
-        await q.edit_message_text(
-            ("پنل‌های فعال برای ساخت یوزر جدید را انتخاب کن:" if mode == "create"
-             else f"پنل‌های فعال را برای <b>{context.user_data.get('panel_select_username')}</b> انتخاب/غیرفعال کن:"),
-            reply_markup=_panel_select_kb(panels, selected, mode), parse_mode="HTML"
-        )
-        return ASK_SELECT_PANELS
+        sid = int(cmd)
+        uid = update.effective_user.id
+        selected_ids = list_service_panel_ids(sid)
+        if not selected_ids:
+            await q.edit_message_text("این سرویس هیچ پنلی ندارد.")
+            return ConversationHandler.END
+        await finalize_create_on_selected(q, context, uid, selected_ids)
+        set_local_user_service(uid, context.user_data.get("new_username"), sid)
+        return ConversationHandler.END
 
     # ---------- panel cfg selector actions ----------
     if data.startswith("pcfg:"):
@@ -1472,6 +1698,33 @@ async def show_panel_card(q, context: ContextTypes.DEFAULT_TYPE, owner_id: int, 
     await q.edit_message_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
     return ConversationHandler.END
 
+async def show_service_card(q, context: ContextTypes.DEFAULT_TYPE, service_id: int, notice: str = None):
+    s = get_service(service_id)
+    if not s:
+        await q.edit_message_text("سرویس پیدا نشد.")
+        return ConversationHandler.END
+    lines = []
+    if notice:
+        lines.append(notice)
+    lines.append(f"🧩 <b>{s['name']}</b>")
+    pids = list_service_panel_ids(service_id)
+    if pids:
+        names = []
+        panels = list_my_panels_admin(q.from_user.id)
+        for p in panels:
+            if int(p["id"]) in pids:
+                names.append(p["name"])
+        lines.append("Panels: " + ", ".join(names))
+    lines.append("\nچه کاری انجام بدهم؟")
+    kb = [
+        [InlineKeyboardButton("🧷 Assign Panels", callback_data="service_assign_panels")],
+        [InlineKeyboardButton("✏️ Rename Service", callback_data="service_rename")],
+        [InlineKeyboardButton("🗑️ Remove Service", callback_data="service_delete")],
+        [InlineKeyboardButton("⬅️ Back", callback_data="manage_services")],
+    ]
+    await q.edit_message_text("\n".join(lines), reply_markup=InlineKeyboardMarkup(kb), parse_mode="HTML")
+    return ConversationHandler.END
+
 async def show_user_card(q, owner_id: int, uname: str, notice: str = None):
     row = get_local_user(owner_id, uname)
     if not row:
@@ -1505,7 +1758,7 @@ async def show_user_card(q, owner_id: int, uname: str, notice: str = None):
         [InlineKeyboardButton("✏️ Edit Limit", callback_data="act_edit_limit")],
         [InlineKeyboardButton("🧹 Reset Used", callback_data="act_reset_used")],
         [InlineKeyboardButton("🔁 Renew (add days)", callback_data="act_renew")],
-        [InlineKeyboardButton("🧩 Panels", callback_data="act_user_panels")],
+        [InlineKeyboardButton("🧰 Assign Service", callback_data="act_assign_service")],
         [InlineKeyboardButton("🗑️ Delete User", callback_data="act_del_user")],
         [InlineKeyboardButton("⬅️ Back", callback_data="list_users:0")],
     ]
@@ -1543,6 +1796,7 @@ async def show_agent_card(q, context: ContextTypes.DEFAULT_TYPE, agent_tg_id: in
         [InlineKeyboardButton("📛 Set Max/User", callback_data="agent_set_max_user")],
         [InlineKeyboardButton("🔁 Renew (days)", callback_data="agent_renew_days")],
         [InlineKeyboardButton("🧩 Assign Panels", callback_data="agent_assign_panels")],
+        [InlineKeyboardButton("🧰 Assign Service", callback_data="agent_assign_service")],
         [InlineKeyboardButton("🔘 Toggle Active", callback_data="agent_toggle_active")],
         [InlineKeyboardButton("⬅️ Back", callback_data="manage_agents")],
     ]
@@ -1554,8 +1808,34 @@ async def show_assign_panels(q, context: ContextTypes.DEFAULT_TYPE, agent_tg_id:
     selected = set(list_agent_panel_ids(agent_tg_id))
     context.user_data["agent_tg_id"] = agent_tg_id
     context.user_data["ap_selected"] = selected
-    kb = _panel_select_kb(panels, selected, mode="assign")
+    kb = _panel_select_kb(panels, selected)
     await q.edit_message_text("پنل‌های این نماینده:", reply_markup=kb)
+    return ConversationHandler.END
+
+# ---------- service mgmt (admin only) ----------
+async def got_service_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("دسترسی ندارید.")
+        return ConversationHandler.END
+    name = (update.message.text or "").strip()
+    if not name:
+        await update.message.reply_text("❌ اسم معتبر بفرست:")
+        return ASK_SERVICE_NAME
+    sid = create_service(name)
+    await update.message.reply_text("✅ سرویس ایجاد شد.")
+    return ConversationHandler.END
+
+async def got_service_new_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        return ConversationHandler.END
+    name = (update.message.text or "").strip()
+    if not name:
+        await update.message.reply_text("❌ اسم معتبر بفرست:")
+        return ASK_EDIT_SERVICE_NAME
+    sid = context.user_data.get("service_id")
+    with with_mysql_cursor(dict_=False) as cur:
+        cur.execute("UPDATE services SET name=%s WHERE id=%s", (name, sid))
+    await update.message.reply_text("✅ نام سرویس تغییر کرد.")
     return ConversationHandler.END
 
 # ---------- add/edit panels (admin only) ----------
@@ -1892,7 +2172,7 @@ async def got_duration(update: Update, context: ContextTypes.DEFAULT_TYPE):
     class FakeMsg:
         async def edit_message_text(self, *args, **kwargs):
             await update.message.reply_text(*args, **kwargs)
-    return await show_panel_select(FakeMsg(), context, update.effective_user.id, mode="create")
+    return await show_service_select(FakeMsg(), context, update.effective_user.id)
 
 async def got_search(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = (update.message.text or "").strip()
@@ -2084,7 +2364,7 @@ async def finalize_create_on_selected(q, context, owner_id: int, selected_ids: s
         txt += "\n⚠️ خطاها:\n" + "\n".join(f"• {e}" for e in failed[:8])
     await q.edit_message_text(txt)
 
-async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: set):
+def sync_user_panels(owner_id: int, username: str, selected_ids: set):
     links_map = map_linked_remote_usernames(owner_id, username)
     current = set(links_map.keys())
     to_add = selected_ids - current
@@ -2268,9 +2548,9 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
                 api = get_api(p.get("panel_type"))
                 remotes = remote.split(",") if p.get("panel_type") == "sanaei" else [remote]
                 for rn in remotes:
-                    ok, err = api.disable_remote_user(p["panel_url"], p["access_token"], rn)
+                    ok, err = api.remove_remote_user(p["panel_url"], p["access_token"], rn)
                     if not ok:
-                        added_errs.append(f"disable on {p['panel_url']}: {err or 'unknown error'}")
+                        added_errs.append(f"remove on {p['panel_url']}: {err or 'unknown error'}")
 
     for pid in selected_ids:
         p = panels_map.get(int(pid))
@@ -2291,10 +2571,16 @@ async def apply_edit_user_panels(q, owner_id: int, username: str, selected_ids: 
             save_link(owner_id, username, int(pid), remote)
             links_map[int(pid)] = remote
 
-    note = f"✅ اعمال شد. اضافه/ایجاد: {added_ok} | حذف مپ/دیسیبل: {removed} | فعال‌شده‌ها: {enabled_ok}"
+    log.info(
+        "sync_user_panels %s/%s -> add:%d remove:%d enable:%d",
+        owner_id,
+        username,
+        added_ok,
+        removed,
+        enabled_ok,
+    )
     if added_errs:
-        note += "\n⚠️ خطاها:\n" + "\n".join(f"• {e}" for e in added_errs[:10])
-    await show_user_card(q, owner_id, username, notice=note)
+        log.warning("sync_user_panels errors: %s", "; ".join(added_errs[:10]))
 
 # ---------- wiring ----------
 def build_app():
@@ -2332,13 +2618,18 @@ def build_app():
             ASK_AGENT_MAX_USERS:   [MessageHandler(filters.TEXT & ~filters.COMMAND, got_agent_user_limit)],
             ASK_AGENT_MAX_USER_GB: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_agent_max_user_gb)],
 
+            # service mgmt (admin)
+            ASK_SERVICE_NAME:     [MessageHandler(filters.TEXT & ~filters.COMMAND, got_service_name)],
+            ASK_EDIT_SERVICE_NAME:[MessageHandler(filters.TEXT & ~filters.COMMAND, got_service_new_name)],
+            ASK_ASSIGN_SERVICE_PANELS: [CallbackQueryHandler(on_button)],
+
             # user creation
             ASK_NEWUSER_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, got_newuser_name)],
             ASK_LIMIT_GB:     [MessageHandler(filters.TEXT & ~filters.COMMAND, got_limit)],
             ASK_DURATION:     [MessageHandler(filters.TEXT & ~filters.COMMAND, got_duration)],
 
-            # panel multi-select (create/edit)
-            ASK_SELECT_PANELS: [CallbackQueryHandler(on_button)],
+            # service selection for new user
+            ASK_SELECT_SERVICE: [CallbackQueryHandler(on_button)],
 
             # search/manage
             ASK_SEARCH_USER:  [MessageHandler(filters.TEXT & ~filters.COMMAND, got_search)],

--- a/marzban.py
+++ b/marzban.py
@@ -159,6 +159,51 @@ def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Reset traffic statistics for *username* on the panel."""
+    try:
+        r = requests.post(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/user/{username}/reset"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def update_remote_user(
+    panel_url: str,
+    token: str,
+    username: str,
+    data_limit: Optional[int] = None,
+    expire: Optional[int] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Update quota or expiry for *username* on the panel."""
+    payload: Dict[str, int] = {}
+    if data_limit is not None:
+        payload["data_limit"] = int(data_limit)
+        payload["data_limit_reset_strategy"] = "no_reset"
+    if expire is not None:
+        payload["expire"] = int(expire)
+    if not payload:
+        return True, None
+    try:
+        r = requests.put(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/user/{username}"),
+            json=payload,
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL.
 

--- a/marzneshin.py
+++ b/marzneshin.py
@@ -132,6 +132,51 @@ def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Reset traffic statistics for *username* on the panel."""
+    try:
+        r = requests.post(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/users/{username}/reset"),
+            headers=get_headers(token),
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def update_remote_user(
+    panel_url: str,
+    token: str,
+    username: str,
+    data_limit: Optional[int] = None,
+    expire: Optional[int] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Update quota or expiry for *username* on the panel."""
+    payload: Dict[str, int] = {}
+    if data_limit is not None:
+        payload["data_limit"] = int(data_limit)
+        payload["data_limit_reset_strategy"] = "no_reset"
+    if expire is not None:
+        payload["expire"] = int(expire)
+    if not payload:
+        return True, None
+    try:
+        r = requests.put(
+            urljoin(panel_url.rstrip('/') + '/', f"/api/users/{username}"),
+            json=payload,
+            headers={**get_headers(token), "Content-Type": "application/json"},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL."""
     try:

--- a/marzneshin.py
+++ b/marzneshin.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin
+from datetime import datetime, timezone
 
 import requests
 
@@ -155,13 +156,15 @@ def update_remote_user(
     expire: Optional[int] = None,
 ) -> Tuple[bool, Optional[str]]:
     """Update quota or expiry for *username* on the panel."""
-    payload: Dict[str, int] = {}
+    payload: Dict[str, object] = {"username": username}
     if data_limit is not None:
         payload["data_limit"] = int(data_limit)
         payload["data_limit_reset_strategy"] = "no_reset"
     if expire is not None:
-        payload["expire"] = int(expire)
-    if not payload:
+        dt = datetime.fromtimestamp(int(expire), tz=timezone.utc)
+        payload["expire_strategy"] = "fixed_date"
+        payload["expire_date"] = dt.isoformat().replace("+00:00", "Z")
+    if len(payload) == 1:
         return True, None
     try:
         r = requests.put(

--- a/sanaei.py
+++ b/sanaei.py
@@ -242,6 +242,63 @@ def remove_remote_user(panel_url: str, token: str, username: str) -> Tuple[bool,
         return False, str(e)[:200]
 
 
+def reset_remote_user_usage(panel_url: str, token: str, username: str) -> Tuple[bool, Optional[str]]:
+    """Reset traffic statistics for *username* on the panel."""
+    try:
+        inbounds, err = _list_inbounds(panel_url, token)
+        if err:
+            return False, err
+        inbound, client = _find_client(inbounds, username)
+        if not inbound or not client:
+            return False, 'not found'
+        url = urljoin(
+            panel_url.rstrip('/') + '/',
+            f"panel/api/inbounds/{inbound.get('id')}/resetClientTraffic/{username}",
+        )
+        r = requests.post(url, headers=get_headers(token), timeout=20)
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
+def update_remote_user(
+    panel_url: str,
+    token: str,
+    username: str,
+    data_limit: Optional[int] = None,
+    expire: Optional[int] = None,
+) -> Tuple[bool, Optional[str]]:
+    """Update quota or expiry for *username* on the panel."""
+    try:
+        inbounds, err = _list_inbounds(panel_url, token)
+        if err:
+            return False, err
+        inbound, client = _find_client(inbounds, username)
+        if not inbound or not client:
+            return False, 'not found'
+        if data_limit is not None:
+            client['totalGB'] = int(data_limit)
+        if expire is not None:
+            client['expiryTime'] = int(expire)
+        payload = {
+            'id': inbound.get('id'),
+            'settings': json.dumps({'clients': [client]}, separators=(',', ':')),
+        }
+        r = requests.post(
+            urljoin(panel_url.rstrip('/') + '/', f"panel/api/inbounds/updateClient/{client.get('id')}")
+            ,json=payload,
+            headers={**get_headers(token), 'Content-Type': 'application/json'},
+            timeout=20,
+        )
+        if r.status_code == 200:
+            return True, None
+        return False, f"{r.status_code} {r.text[:200]}"
+    except Exception as e:  # pragma: no cover - network errors
+        return False, str(e)[:200]
+
+
 def fetch_subscription_links(sub_url: str) -> List[str]:
     """Return links from a subscription URL if provided.
 

--- a/sanaei.py
+++ b/sanaei.py
@@ -281,7 +281,7 @@ def update_remote_user(
         if data_limit is not None:
             client['totalGB'] = int(data_limit)
         if expire is not None:
-            client['expiryTime'] = int(expire)
+            client['expiryTime'] = int(expire) * 1000
         payload = {
             'id': inbound.get('id'),
             'settings': json.dumps({'clients': [client]}, separators=(',', ':')),


### PR DESCRIPTION
## Summary
- remove panel selection from user management, leaving only service assignment
- propagate service panel changes by creating/removing user accounts via panel APIs and updating usage sync links
- push renews, resets and limit edits to linked panels through their APIs

## Testing
- `python -m py_compile bot.py marzban.py marzneshin.py sanaei.py usage_sync.py`


------
https://chatgpt.com/codex/tasks/task_b_68bc5c9c992883288b5c2529cd2d10e1